### PR TITLE
Verify if there is an error when requesting a ticket

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -241,3 +241,18 @@ func getErrorFromResponse(body []byte) error {
 
 	return errors.New(s.Status)
 }
+
+func isErrorResponse(body []byte) bool {
+        type errorStatus struct {
+                Error  bool   `json:"error"`
+                Status string `json:"status"`
+        }
+
+        s := &errorStatus{}
+        err := json.Unmarshal(body, &s)
+        if err != nil {
+                return false
+        }
+
+        return s.Error
+}

--- a/internal/api/ticket.go
+++ b/internal/api/ticket.go
@@ -27,6 +27,10 @@ func (api *API) GetTicket(from, to address.HashAddress, subscriptionID string) (
 	if statusCode < 200 || statusCode > 299 {
 		return nil, errNoSuccess
 	}
+	
+	if (isErrorResponse(body)) {
+                return nil, getErrorFromResponse(body)
+        }
 
 	// Parse body for ticket
 	t := &ticket.Ticket{}
@@ -58,6 +62,10 @@ func (api *API) GetAnonymousTicket(from, to address.HashAddress, subscriptionID 
 	if (statusCode < 200 || statusCode > 299) && statusCode != 412 {
 		return nil, getErrorFromResponse(body)
 	}
+	
+	if (isErrorResponse(body)) {
+                return nil, getErrorFromResponse(body)
+        }
 
 	// Parse body for ticket
 	t := &ticket.Ticket{}
@@ -89,6 +97,10 @@ func (api *API) GetAnonymousTicketByProof(id string, proof uint64) (*ticket.Tick
 	if statusCode < 200 || statusCode > 299 {
 		return nil, errNoSuccess
 	}
+	
+	if (isErrorResponse(body)) {
+                return nil, getErrorFromResponse(body)
+        }
 
 	// Parse body for ticket
 	newT := &ticket.Ticket{}


### PR DESCRIPTION
If the server can't issue a ticket to deliver a message the server will crash. This PR will check for an error to avoid crashing.