### PR TITLE
Bm 83: jwt token time issues should be displayed properly

### DIFF
--- a/cmd/bm-client/cmd/api_create.go
+++ b/cmd/bm-client/cmd/api_create.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal"
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal/container"
 	"github.com/bitmaelum/bitmaelum-suite/internal/api"
 	"github.com/bitmaelum/bitmaelum-suite/internal/key"
@@ -58,7 +59,7 @@ var apiCreateCmd = &cobra.Command{
 		fmt.Printf("%#v\n", key)
 		fmt.Printf("%#v\n", *acValidUntil)
 
-		client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing)
+		client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
 		if err != nil {
 			logrus.Fatal(err)
 			os.Exit(1)

--- a/cmd/bm-client/cmd/api_list.go
+++ b/cmd/bm-client/cmd/api_list.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal"
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal/container"
 	"github.com/bitmaelum/bitmaelum-suite/internal/api"
 	"github.com/bitmaelum/bitmaelum-suite/internal/vault"
@@ -47,7 +48,7 @@ var apiListCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing)
+		client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
 		if err != nil {
 			logrus.Fatal(err)
 			os.Exit(1)

--- a/cmd/bm-client/cmd/auth_list.go
+++ b/cmd/bm-client/cmd/auth_list.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal"
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal/container"
 	"github.com/bitmaelum/bitmaelum-suite/internal/api"
 	"github.com/bitmaelum/bitmaelum-suite/internal/vault"
@@ -47,7 +48,7 @@ var authListCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing)
+		client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
 		if err != nil {
 			logrus.Fatal(err)
 			os.Exit(1)

--- a/cmd/bm-client/handlers/auth_create.go
+++ b/cmd/bm-client/handlers/auth_create.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal"
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal/container"
 	"github.com/bitmaelum/bitmaelum-suite/internal/api"
 	"github.com/bitmaelum/bitmaelum-suite/internal/key"
@@ -62,5 +63,5 @@ func getAPIClient(info *vault.AccountInfo) (*api.API, error) {
 		return nil, errNoRoutingID
 	}
 
-	return api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing)
+	return api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
 }

--- a/cmd/bm-client/handlers/compose.go
+++ b/cmd/bm-client/handlers/compose.go
@@ -20,6 +20,7 @@
 package handlers
 
 import (
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal"
 	"github.com/bitmaelum/bitmaelum-suite/internal/api"
 	"github.com/bitmaelum/bitmaelum-suite/internal/message"
 	"github.com/bitmaelum/bitmaelum-suite/internal/messages"
@@ -33,7 +34,7 @@ func ComposeMessage(addressing message.Addressing, subject string, b, a []string
 	}
 
 	// Setup API connection to the server
-	client, err := api.NewAuthenticated(addressing.Sender.Address, addressing.Sender.PrivKey, addressing.Sender.Host)
+	client, err := api.NewAuthenticated(addressing.Sender.Address, addressing.Sender.PrivKey, addressing.Sender.Host, internal.JwtErrorFunc)
 	if err != nil {
 		return err
 	}

--- a/cmd/bm-client/handlers/create_account.go
+++ b/cmd/bm-client/handlers/create_account.go
@@ -23,8 +23,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal"
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal/container"
-	"github.com/bitmaelum/bitmaelum-suite/internal"
+	bminternal "github.com/bitmaelum/bitmaelum-suite/internal"
 	"github.com/bitmaelum/bitmaelum-suite/internal/api"
 	"github.com/bitmaelum/bitmaelum-suite/internal/config"
 	"github.com/bitmaelum/bitmaelum-suite/internal/resolver"
@@ -120,7 +121,7 @@ func CreateAccount(v *vault.Vault, bmAddr, name, token string, kt bmcrypto.KeyTy
 	if info == nil {
 		fmt.Printf("* Generating your secret key to send and read mail: ")
 
-		mnemonic, privKey, pubKey, err := internal.GenerateKeypairWithMnemonic(kt)
+		mnemonic, privKey, pubKey, err := bminternal.GenerateKeypairWithMnemonic(kt)
 
 		if err != nil {
 			fmt.Print(err)
@@ -164,7 +165,7 @@ func CreateAccount(v *vault.Vault, bmAddr, name, token string, kt bmcrypto.KeyTy
 	}
 
 	fmt.Printf("* Sending your account information to the server: ")
-	client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing)
+	client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
 	if err != nil {
 		// Remove account from the local vault as well, as we could not store on the server
 		v.RemoveAccount(*addr)
@@ -213,7 +214,7 @@ If, for any reason, you lose this key, you will need to use the following
 words in order to recreate the key:
 
 `)
-		fmt.Print(internal.WordWrap(mnemonicToShow, 78))
+		fmt.Print(bminternal.WordWrap(mnemonicToShow, 78))
 		fmt.Print(`
 
 Write these words down and store them in a secure environment. They are the 

--- a/cmd/bm-client/handlers/fetch_messages.go
+++ b/cmd/bm-client/handlers/fetch_messages.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal"
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal/container"
 	"github.com/bitmaelum/bitmaelum-suite/internal/api"
 	"github.com/bitmaelum/bitmaelum-suite/internal/message"
@@ -50,7 +51,7 @@ func FetchMessages(accounts []vault.AccountInfo) {
 			continue
 		}
 
-		client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing)
+		client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
 		if err != nil {
 			continue
 		}

--- a/cmd/bm-client/handlers/read_message.go
+++ b/cmd/bm-client/handlers/read_message.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal"
 	"github.com/bitmaelum/bitmaelum-suite/internal/api"
 	"github.com/bitmaelum/bitmaelum-suite/internal/message"
 	"github.com/bitmaelum/bitmaelum-suite/internal/resolver"
@@ -35,7 +36,7 @@ import (
 
 // ReadMessage will read a specific message blocks
 func ReadMessage(info *vault.AccountInfo, routingInfo *resolver.RoutingInfo, box, messageID string) {
-	client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing)
+	client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/cmd/bm-client/internal/error.go
+++ b/cmd/bm-client/internal/error.go
@@ -1,3 +1,22 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 package internal
 
 import (
@@ -12,7 +31,7 @@ import (
 
 // JwtErrorFunc is a generic error handling function that can be attached to an API client. This will automatically
 // trigger whenever an error (https response >= 400) is found. In this case, it will only check for the token-time
-// error, which is returned when the time of the client is off. 
+// error, which is returned when the time of the client is off.
 func JwtErrorFunc(_ *http.Request, resp *http.Response) {
 	if resp.StatusCode != 401 {
 		return
@@ -26,7 +45,8 @@ func JwtErrorFunc(_ *http.Request, resp *http.Response) {
 	if err != nil && err.Error() == "token time not valid" {
 		fmt.Println("The connection to the server was unauthenticated because of timing issues. It seems that your computer time is not")
 		fmt.Println("set to the current time. This causes issues in communication with the BitMaelum server. Please update your time and")
-		fmt.Println("try again.\n")
+		fmt.Println("try again.")
+		fmt.Println("")
 		os.Exit(1)
 	}
 

--- a/cmd/bm-client/internal/error.go
+++ b/cmd/bm-client/internal/error.go
@@ -1,0 +1,35 @@
+package internal
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/bitmaelum/bitmaelum-suite/internal/api"
+)
+
+// JwtErrorFunc is a generic error handling function that can be attached to an API client. This will automatically
+// trigger whenever an error (https response >= 400) is found. In this case, it will only check for the token-time
+// error, which is returned when the time of the client is off. 
+func JwtErrorFunc(_ *http.Request, resp *http.Response) {
+	if resp.StatusCode != 401 {
+		return
+	}
+
+	// Read body
+	b, _ := ioutil.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	err := api.GetErrorFromResponse(b)
+	if err != nil && err.Error() == "token time not valid" {
+		fmt.Println("The connection to the server was unauthenticated because of timing issues. It seems that your computer time is not")
+		fmt.Println("set to the current time. This causes issues in communication with the BitMaelum server. Please update your time and")
+		fmt.Println("try again.\n")
+		os.Exit(1)
+	}
+
+	// Whoops.. not an error. Let's pretend nothing happened and create a new buffer so we can read the body again
+	resp.Body = ioutil.NopCloser(bytes.NewReader(b))
+}

--- a/cmd/bm-server/middleware/auth/auth_apikey_test.go
+++ b/cmd/bm-server/middleware/auth/auth_apikey_test.go
@@ -145,15 +145,17 @@ func createReq(auth string, addr string) *http.Request {
 }
 
 func checkFalse(t *testing.T, a middleware.Authenticator, req *http.Request) {
-	ctx, ok := a.Authenticate(req, "")
-	assert.False(t, ok)
+	status, ctx, err := a.Authenticate(req, "")
+	assert.Equal(t, status, middleware.AuthStatusPass)
 	assert.Nil(t, ctx)
+	assert.NoError(t, err)
 }
 
 func checkTrue(t *testing.T, a middleware.Authenticator, req *http.Request, hash string) {
-	ctx, ok := a.Authenticate(req, "")
-	assert.True(t, ok)
+	status, ctx, err := a.Authenticate(req, "")
+	assert.Equal(t, status, middleware.AuthStatusSuccess)
 	assert.Equal(t, hash, ctx.Value(AddressContext))
+	assert.NoError(t, err)
 }
 
 func checkKey(t *testing.T, a APIKeyAuth, shouldPass bool, token, addr, routeName string) {
@@ -163,10 +165,11 @@ func checkKey(t *testing.T, a APIKeyAuth, shouldPass bool, token, addr, routeNam
 		"addr": hash.New(addr).String(),
 	})
 
-	ctx, ok := a.Authenticate(req, routeName)
+	status, ctx, err := a.Authenticate(req, routeName)
 	if shouldPass {
-		assert.True(t, ok)
+		assert.Equal(t, status, middleware.AuthStatusSuccess)
 		assert.NotNil(t, ctx)
+		assert.NoError(t, err)
 		// Check token in context
 		k := ctx.Value(APIKeyContext).(*key.APIKeyType)
 		assert.Equal(t, token, k.ID)
@@ -174,6 +177,7 @@ func checkKey(t *testing.T, a APIKeyAuth, shouldPass bool, token, addr, routeNam
 		return
 	}
 
-	assert.False(t, ok)
+	assert.NoError(t, err)
+	assert.Equal(t, status, middleware.AuthStatusPass)
 	assert.Nil(t, ctx)
 }

--- a/cmd/bm-server/middleware/auth/auth_onbehalf_jwt.go
+++ b/cmd/bm-server/middleware/auth/auth_onbehalf_jwt.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/container"
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/middleware"
 	"github.com/bitmaelum/bitmaelum-suite/internal/api"
 	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
 	"github.com/gorilla/mux"
@@ -36,43 +37,48 @@ import (
 type OnBehalfJwtAuth struct{}
 
 // Authenticate will check if an API key matches the request
-func (mw *OnBehalfJwtAuth) Authenticate(req *http.Request, _ string) (context.Context, bool) {
+func (mw *OnBehalfJwtAuth) Authenticate(req *http.Request, _ string) (middleware.AuthStatus, context.Context, error) {
 	// Check if the address actually exists
 	haddr, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		return nil, false
+		return middleware.AuthStatusPass, nil, err
 	}
 
 	accountRepo := container.Instance.GetAccountRepo()
 	if !accountRepo.Exists(*haddr) {
 		logrus.Trace("auth: address not found")
-		return nil, false
+		return middleware.AuthStatusPass, nil, nil
 	}
 
 	// Check token
 	token, err := checkOnBehalfToken(req.Header.Get("Authorization"), *haddr)
 	if err != nil {
+		if err == api.ErrTokenTimeNotValid {
+			logrus.Trace("auth: invalid time for token: ", err)
+			return middleware.AuthStatusFailure, nil, err
+		}
+
 		logrus.Trace("auth: incorrect token: ", err)
-		return nil, false
+		return middleware.AuthStatusPass, nil, nil
 	}
 
 	ctx := req.Context()
 	ctx = context.WithValue(ctx, ClaimsContext, token.Claims)
 	ctx = context.WithValue(ctx, AddressContext, token.Claims.(*jwt.StandardClaims).Subject)
 
-	return ctx, true
+	return middleware.AuthStatusSuccess, ctx, nil
 }
 
 // Check if the authorization contains a valid JWT token for the given address
 func checkOnBehalfToken(bearerToken string, addr hash.Hash) (*jwt.Token, error) {
 	if bearerToken == "" {
 		logrus.Trace("auth: empty auth string")
-		return nil, ErrTokenNotValidated
+		return nil, api.ErrTokenNotValid
 	}
 
 	if len(bearerToken) <= 6 || strings.ToUpper(bearerToken[0:7]) != "BEARER " {
 		logrus.Trace("auth: bearer not found")
-		return nil, ErrTokenNotValidated
+		return nil, api.ErrTokenNotValid
 	}
 	tokenString := bearerToken[7:]
 
@@ -80,7 +86,7 @@ func checkOnBehalfToken(bearerToken string, addr hash.Hash) (*jwt.Token, error) 
 	keys, err := authRepo.FetchByHash(addr.String())
 	if err != nil {
 		logrus.Trace("auth: cannot fetch keys: ", err)
-		return nil, ErrTokenNotValidated
+		return nil, api.ErrTokenNotValid
 	}
 
 	for _, key := range keys {
@@ -88,6 +94,14 @@ func checkOnBehalfToken(bearerToken string, addr hash.Hash) (*jwt.Token, error) 
 		if err != nil {
 			continue
 		}
+
+		// If the token is not valid in time, we can fail directly
+		if err == api.ErrTokenTimeNotValid {
+			logrus.Trace("auth: no key found that validates the token")
+			return nil, err
+		}
+
+		// @TODO: does this code is still valid after we checked times above
 
 		// check if expired
 		now := jwt.TimeFunc()
@@ -100,5 +114,5 @@ func checkOnBehalfToken(bearerToken string, addr hash.Hash) (*jwt.Token, error) 
 	}
 
 	logrus.Trace("auth: no key found that validates the token")
-	return nil, ErrTokenNotValidated
+	return nil, api.ErrTokenNotValid
 }

--- a/cmd/bm-server/processor/process.go
+++ b/cmd/bm-server/processor/process.go
@@ -264,5 +264,5 @@ func processTicket(routingInfo resolver.RoutingInfo, addrInfo resolver.AddressIn
 
 // getClient will return an API client pointing to the actual mail server found in the routing info
 func getClient(routingInfo resolver.RoutingInfo) (*api.API, error) {
-	return api.NewAnonymous(routingInfo.Routing)
+	return api.NewAnonymous(routingInfo.Routing, nil)
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,10 +5,14 @@ codecov:
 
 coverage:
   status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
     patch:
      default:
        target: 0%
-       threshold: 0%
+       threshold: 5%
   precision: 2
   round: down
   range: "50...75"

--- a/internal/api/account.go
+++ b/internal/api/account.go
@@ -39,7 +39,7 @@ func (api *API) GetPublicKey(addr hash.Hash) (string, error) {
 	}
 
 	if statusCode < 200 || statusCode > 299 {
-		return "", getErrorFromResponse(resp)
+		return "", GetErrorFromResponse(resp)
 	}
 
 	return output.PublicKey, nil
@@ -71,7 +71,7 @@ func (api *API) CreateAccount(info vault.AccountInfo, token string) error {
 	}
 
 	if statusCode < 200 || statusCode > 299 {
-		return getErrorFromResponse(resp)
+		return GetErrorFromResponse(resp)
 	}
 
 	return nil

--- a/internal/api/apikey.go
+++ b/internal/api/apikey.go
@@ -55,7 +55,7 @@ func (api *API) CreateAPIKey(addrHash hash.Hash, key key.APIKeyType) error {
 	}
 
 	if isErrorResponse(body) {
-		return getErrorFromResponse(body)
+		return GetErrorFromResponse(body)
 	}
 
 	return nil
@@ -74,7 +74,7 @@ func (api *API) DeleteAPIKey(addrHash hash.Hash, ID string) error {
 	}
 
 	if isErrorResponse(body) {
-		return getErrorFromResponse(body)
+		return GetErrorFromResponse(body)
 	}
 
 	return nil
@@ -93,7 +93,7 @@ func (api *API) ListAPIKeys(addrHash hash.Hash) ([]key.APIKeyType, error) {
 	}
 
 	if isErrorResponse(body) {
-		return nil, getErrorFromResponse(body)
+		return nil, GetErrorFromResponse(body)
 	}
 
 	// Parse body for keys
@@ -119,7 +119,7 @@ func (api *API) GetAPIKey(addrHash hash.Hash, ID string) (*key.APIKeyType, error
 	}
 
 	if isErrorResponse(body) {
-		return nil, getErrorFromResponse(body)
+		return nil, GetErrorFromResponse(body)
 	}
 
 	// Parse body for key

--- a/internal/api/authkey.go
+++ b/internal/api/authkey.go
@@ -57,7 +57,7 @@ func (api *API) CreateAuthKey(addrHash hash.Hash, key key.AuthKeyType) error {
 	}
 
 	if isErrorResponse(body) {
-		return getErrorFromResponse(body)
+		return GetErrorFromResponse(body)
 	}
 
 	return nil
@@ -76,7 +76,7 @@ func (api *API) DeleteAuthKey(addrHash hash.Hash, fingerprint string) error {
 	}
 
 	if isErrorResponse(body) {
-		return getErrorFromResponse(body)
+		return GetErrorFromResponse(body)
 	}
 
 	return nil
@@ -95,7 +95,7 @@ func (api *API) ListAuthKeys(addrHash hash.Hash) ([]key.AuthKeyType, error) {
 	}
 
 	if isErrorResponse(body) {
-		return nil, getErrorFromResponse(body)
+		return nil, GetErrorFromResponse(body)
 	}
 
 	// Parse body for keys
@@ -121,7 +121,7 @@ func (api *API) GetAuthKey(addrHash hash.Hash, fingerprint string) (*key.AuthKey
 	}
 
 	if isErrorResponse(body) {
-		return nil, getErrorFromResponse(body)
+		return nil, GetErrorFromResponse(body)
 	}
 
 	// Parse body for key

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -43,12 +43,15 @@ type jsonOut map[string]interface{}
 
 var errNoSuccess = errors.New("operation was not successful")
 
+type serverErrorFunc func(*http.Request, *http.Response)
+
 // API is a structure to connect to the server for the given account
 type API struct {
-	client *http.Client   // internal HTTP client
-	host   string         // host to the server
-	jwt    string         // optional JWT token (for client's authorized communication)
-	ticket *ticket.Ticket // optional ticket for communication
+	client    *http.Client    // internal HTTP client
+	host      string          // host to the server
+	jwt       string          // optional JWT token (for client's authorized communication)
+	ticket    *ticket.Ticket  // optional ticket for communication
+	errorFunc serverErrorFunc // optional function to call when a server call fails
 }
 
 // ClientOpts allows you to configure the API client
@@ -57,19 +60,21 @@ type ClientOpts struct {
 	AllowInsecure bool
 	Debug         bool
 	JWTToken      string
+	ErrorFunc     serverErrorFunc
 }
 
 // NewAnonymous creates a new client that connects anonymously to a BitMaelum server (normally server-to-server communications)
-func NewAnonymous(host string) (*API, error) {
+func NewAnonymous(host string, f serverErrorFunc) (*API, error) {
 	return NewClient(ClientOpts{
 		Host:          host,
 		AllowInsecure: config.Client.Server.AllowInsecure,
 		Debug:         config.Client.Server.DebugHTTP,
+		ErrorFunc:     f,
 	})
 }
 
 // NewAuthenticated creates a new client that connects to a BitMaelum Server with specific credentials (normally client-to-server communications)
-func NewAuthenticated(addr address.Address, key *bmcrypto.PrivKey, host string) (*API, error) {
+func NewAuthenticated(addr address.Address, key *bmcrypto.PrivKey, host string, f serverErrorFunc) (*API, error) {
 	// Create token based on the private key of the user
 	jwtToken, err := GenerateJWTToken(addr.Hash(), *key)
 	if err != nil {
@@ -81,6 +86,7 @@ func NewAuthenticated(addr address.Address, key *bmcrypto.PrivKey, host string) 
 		JWTToken:      jwtToken,
 		AllowInsecure: config.Client.Server.AllowInsecure,
 		Debug:         config.Client.Server.DebugHTTP,
+		ErrorFunc:     f,
 	})
 }
 
@@ -107,6 +113,7 @@ func NewClient(opts ClientOpts) (*API, error) {
 			Timeout:   15 * time.Second,
 		},
 		jwt: opts.JWTToken,
+		errorFunc: opts.ErrorFunc,
 	}, nil
 }
 
@@ -217,6 +224,11 @@ func (api *API) do(req *http.Request) (body io.ReadCloser, statusCode int, err e
 		return nil, 0, err
 	}
 
+	// Call the error function if there was an error
+	if resp.StatusCode >= 400 && api.errorFunc != nil {
+		api.errorFunc(req, resp)
+	}
+
 	return resp.Body, resp.StatusCode, nil
 }
 
@@ -236,7 +248,7 @@ func CanonicalHost(host string) string {
 	return host
 }
 
-func getErrorFromResponse(body []byte) error {
+func GetErrorFromResponse(body []byte) error {
 	type errorStatus struct {
 		Error  bool   `json:"error"`
 		Status string `json:"status"`

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -112,7 +112,7 @@ func NewClient(opts ClientOpts) (*API, error) {
 			Transport: transport,
 			Timeout:   15 * time.Second,
 		},
-		jwt: opts.JWTToken,
+		jwt:       opts.JWTToken,
 		errorFunc: opts.ErrorFunc,
 	}, nil
 }
@@ -248,6 +248,7 @@ func CanonicalHost(host string) string {
 	return host
 }
 
+// GetErrorFromResponse will return an error generated from the body
 func GetErrorFromResponse(body []byte) error {
 	type errorStatus struct {
 		Error  bool   `json:"error"`

--- a/internal/api/mailbox.go
+++ b/internal/api/mailbox.go
@@ -69,7 +69,7 @@ func (api *API) GetMailboxList(addr hash.Hash) (*MailboxList, error) {
 	}
 
 	if statusCode < 200 || statusCode > 299 {
-		return nil, getErrorFromResponse(resp)
+		return nil, GetErrorFromResponse(resp)
 	}
 
 	return in, nil
@@ -85,7 +85,7 @@ func (api *API) GetMailboxMessages(addr hash.Hash, box string) (*MailboxMessages
 	}
 
 	if statusCode < 200 || statusCode > 299 {
-		return nil, getErrorFromResponse(body)
+		return nil, GetErrorFromResponse(body)
 	}
 
 	return in, nil

--- a/internal/api/message.go
+++ b/internal/api/message.go
@@ -47,7 +47,7 @@ func (api *API) GetMessage(addr hash.Hash, box, messageID string) (*Message, err
 	}
 
 	if statusCode < 200 || statusCode > 299 {
-		return nil, getErrorFromResponse(resp)
+		return nil, GetErrorFromResponse(resp)
 	}
 
 	return in, nil

--- a/internal/api/ticket.go
+++ b/internal/api/ticket.go
@@ -49,7 +49,7 @@ func (api *API) GetTicket(from, to hash.Hash, subscriptionID string) (*ticket.Ti
 	}
 
 	if isErrorResponse(body) {
-		return nil, getErrorFromResponse(body)
+		return nil, GetErrorFromResponse(body)
 	}
 
 	// Parse body for ticket
@@ -79,11 +79,11 @@ func (api *API) GetAnonymousTicket(from, to hash.Hash, subscriptionID string) (*
 	}
 
 	if (statusCode < 200 || statusCode > 299) && statusCode != 412 {
-		return nil, getErrorFromResponse(body)
+		return nil, GetErrorFromResponse(body)
 	}
 
 	if isErrorResponse(body) {
-		return nil, getErrorFromResponse(body)
+		return nil, GetErrorFromResponse(body)
 	}
 
 	// Parse body for ticket
@@ -120,7 +120,7 @@ func (api *API) GetAnonymousTicketByProof(from, to hash.Hash, subscriptionID, ti
 	}
 
 	if isErrorResponse(body) {
-		return nil, getErrorFromResponse(body)
+		return nil, GetErrorFromResponse(body)
 	}
 
 	// Parse body for ticket

--- a/internal/api/upload.go
+++ b/internal/api/upload.go
@@ -42,7 +42,7 @@ func (api *API) UploadHeader(t ticket.Ticket, header *message.Header) error {
 	}
 
 	if statusCode < 200 || statusCode > 299 {
-		return getErrorFromResponse(resp)
+		return GetErrorFromResponse(resp)
 	}
 
 	return nil

--- a/pkg/bmcrypto/key_rsa_test.go
+++ b/pkg/bmcrypto/key_rsa_test.go
@@ -36,7 +36,6 @@ func TestString(t *testing.T) {
 	k = NewRsaKey(2048)
 	assert.Equal(t, "RS256", k.JWTSignMethod().Alg())
 
-
 	data, err := ioutil.ReadFile("../../testdata/privkey.rsa")
 	assert.NoError(t, err)
 	privKey, err := PrivateKeyFromString(string(data))


### PR DESCRIPTION
Fixed issue #83 : Changed things around to actually trickle the JWT timing error  down to the api response.

Also added an error handler which can be hooked into our api client. This way, we can easily detect errors and handle them globally. In our case, this would be the single token time issue for now.