### PR TITLE
Webhook system

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ BitMaelum (old Anglo-Saxon for "bit-by-bit") is an attempt. Instead of trying to
 
 To build and test BitMaelum, check out [build document](docs/build.md).
 
+New to BitMaelum? Take a 5-minute tour on [what's it about](https://github.com/bitmaelum/bitmaelum-suite/wiki/BItMaelum-in-5-minutes-or-less)
 
 # Features
 
@@ -42,7 +43,7 @@ To start with BitMaelum right away, check out [Quickstart guide](https://github.
 
 # Development
 
-BitMaelum is currently highly experimental and under heavy development. Do not use it yet in any production environment. 
+BitMaelum is highly experimental and under heavy development. Do not use it yet in any production environment. 
 
 
 <hr>

--- a/cmd/bm-client/cmd/api_list.go
+++ b/cmd/bm-client/cmd/api_list.go
@@ -64,10 +64,16 @@ var apiListCmd = &cobra.Command{
 		table.SetHeader([]string{"ID", "Permissions", "Valid until", "Description"})
 
 		for _, key := range keys {
+			// don't display zero times
+			expiry := key.Expires.Format(time.ANSIC)
+			if key.Expires.Unix() == 0 {
+				expiry = ""
+			}
+
 			table.Append([]string{
 				key.ID,
 				strings.Join(key.Permissions, ","),
-				key.Expires.Format(time.ANSIC),
+				expiry,
 				key.Desc,
 			})
 		}

--- a/cmd/bm-client/cmd/auth_list.go
+++ b/cmd/bm-client/cmd/auth_list.go
@@ -64,9 +64,15 @@ var authListCmd = &cobra.Command{
 		table.SetHeader([]string{"Fingerprint", "Valid until", "Description"})
 
 		for _, key := range keys {
+			// don't display zero times
+			expiry := key.Expires.Format(time.ANSIC)
+			if key.Expires.Unix() == 0 {
+				expiry = ""
+			}
+
 			table.Append([]string{
 				key.Fingerprint,
-				key.Expires.Format(time.ANSIC),
+				expiry,
 				key.Description,
 			})
 		}

--- a/cmd/bm-client/cmd/list_messages.go
+++ b/cmd/bm-client/cmd/list_messages.go
@@ -59,7 +59,14 @@ var listMessagesCmd = &cobra.Command{
 			since = internal.GetReadTime()
 		}
 
-		handlers.ListMessages(v.Store.Accounts, since)
+		msgCount := handlers.ListMessages(v.Store.Accounts, since)
+		if msgCount == 0 {
+			if *lmNew {
+				fmt.Println("* No new messages found")
+			} else {
+				fmt.Println("* No messages since ", since.Format(time.RFC822))
+			}
+		}
 
 		internal.SaveReadTime(time.Now())
 	},

--- a/cmd/bm-client/cmd/webhook.go
+++ b/cmd/bm-client/cmd/webhook.go
@@ -17,30 +17,25 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-package webhook
+package cmd
 
 import (
-	"testing"
-
-	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
+	"github.com/spf13/cobra"
 )
 
-func TestWebhook(t *testing.T) {
-	cfg := ConfigHTTP{
-		URL: "https://foo.bar/test",
-	}
+var webhookCmd = &cobra.Command{
+	Use:   "webhook",
+	Short: "Webhook management",
+}
 
-	a, err := NewWebhook(hash.New("example!"), EventLocalDelivery, TypeHTTP, cfg)
-	assert.NoError(t, err)
+var (
+	whAccount *string
+)
 
-	u, err := uuid.Parse(a.ID)
-	assert.NoError(t, err)
-	assert.Equal(t, "VERSION_4", u.Version().String())
-	assert.Equal(t, "2e4551de804e27aacf20f9df5be3e8cd384ed64488b21ab079fb58e8c90068ab", a.Account.String())
-	assert.Equal(t, TypeHTTP, a.Type)
-	assert.Equal(t, "{\"URL\":\"https://foo.bar/test\"}", string(a.Config))
-	assert.False(t, a.Enabled)
-	assert.Equal(t, EventLocalDelivery, a.Event)
+func init() {
+	rootCmd.AddCommand(webhookCmd)
+
+	whAccount = webhookCmd.PersistentFlags().StringP("account", "a", "", "Account")
+
+	_ = webhookCmd.MarkPersistentFlagRequired("account")
 }

--- a/cmd/bm-client/cmd/webhook_create.go
+++ b/cmd/bm-client/cmd/webhook_create.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var webhookCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Creates a new webhook",
+}
+
+var whEvent *string
+
+func init() {
+	webhookCmd.AddCommand(webhookCreateCmd)
+
+	webhookCreateCmd.SetHelpTemplate(`The following webhooks events (--event or -e) are supported:
+
+  localdelivery       When a message is delivered locally
+  faileddelivery      When a message cannot be delivered
+  remotedelivery      When a message is delivered remotely (outgoing mail)
+
+  apikeycreated       When an API key has been created
+  apikeydeleted       When an API key has been deleted
+  apikeyupdated       When an API key has been updated
+
+  authkeycreated      When an auth key has been created
+  authkeydeleted      When an auth key has been deleted
+  authkeyupdated      When an auth key has been updated
+
+  webhookcreated      When a webhook has been created
+  webhookdeleted      When a webhook has been deleted
+  webhookupdated      When a webhook has been updated
+
+or use "all" to trigger on ALL webhook events.
+			
+`)
+
+	whEvent = webhookCreateCmd.PersistentFlags().StringP("event", "e", "", "Event to use (see 'bm-client webhook create' for options)")
+
+	_ = webhookCreateCmd.MarkPersistentFlagRequired("event")
+}

--- a/cmd/bm-client/cmd/webhook_create_http.go
+++ b/cmd/bm-client/cmd/webhook_create_http.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal"
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal/container"
+	"github.com/bitmaelum/bitmaelum-suite/internal/api"
+	"github.com/bitmaelum/bitmaelum-suite/internal/vault"
+	"github.com/bitmaelum/bitmaelum-suite/internal/webhook"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var webhookCreateHTTPCmd = &cobra.Command{
+	Use:   "http",
+	Short: "Display all webhooks for this account on the server",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		// Validate event
+		evt, err := webhook.NewEventFromString(*whEvent)
+		if err != nil {
+			fmt.Println("unknown event: ", *whEvent)
+			fmt.Println("")
+
+			_ = webhookCreateCmd.Help()
+			os.Exit(1)
+		}
+
+		v := vault.OpenVault()
+		info := vault.GetAccountOrDefault(v, *whAccount)
+
+		resolver := container.Instance.GetResolveService()
+		routingInfo, err := resolver.ResolveRouting(info.RoutingID)
+		if err != nil {
+			logrus.Fatal("Cannot find routing ID for this account")
+			os.Exit(1)
+		}
+
+		cfg := &webhook.ConfigHTTP{
+			URL: "https://www.example.org/foo/bar",
+		}
+		wh, err := webhook.NewWebhook(info.Address.Hash(), evt, webhook.TypeHTTP, cfg)
+		if err != nil {
+			logrus.Fatal("Cannot create webhook")
+			os.Exit(1)
+		}
+
+		client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
+		if err != nil {
+			logrus.Fatal(err)
+			os.Exit(1)
+		}
+
+		err = client.CreateWebhook(*wh)
+		fmt.Println(err)
+
+		/*
+			webhooks, err := client.ListWebhooks(info.Address.Hash())
+			if err != nil {
+				logrus.Fatal("cannot fetch webhooks: ", err)
+				os.Exit(1)
+			}
+		*/
+	},
+}
+
+func init() {
+	webhookCreateCmd.AddCommand(webhookCreateHTTPCmd)
+}

--- a/cmd/bm-client/cmd/webhook_create_http.go
+++ b/cmd/bm-client/cmd/webhook_create_http.go
@@ -59,7 +59,7 @@ var webhookCreateHTTPCmd = &cobra.Command{
 		}
 
 		cfg := &webhook.ConfigHTTP{
-			URL: *whhUrl,
+			URL: *whhURL,
 		}
 		wh, err := webhook.NewWebhook(info.Address.Hash(), evt, webhook.TypeHTTP, cfg)
 		if err != nil {
@@ -79,16 +79,16 @@ var webhookCreateHTTPCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		fmt.Println("Created webhook %s", wh.ID)
+		fmt.Printf("Created webhook %s\n", wh.ID)
 	},
 }
 
-var whhUrl *string
+var whhURL *string
 
 func init() {
 	webhookCreateCmd.AddCommand(webhookCreateHTTPCmd)
 
-	whhUrl = webhookCreateHTTPCmd.Flags().String("url", "", "HTTP webhook URL to send POST to")
+	whhURL = webhookCreateHTTPCmd.Flags().String("url", "", "HTTP webhook URL to send POST to")
 
 	_ = webhookCreateHTTPCmd.MarkFlagRequired("url")
 }

--- a/cmd/bm-client/cmd/webhook_create_slack.go
+++ b/cmd/bm-client/cmd/webhook_create_slack.go
@@ -32,9 +32,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var webhookCreateHTTPCmd = &cobra.Command{
-	Use:   "http",
-	Short: "Display all webhooks for this account on the server",
+var webhookCreateSlackCmd = &cobra.Command{
+	Use:   "slack",
+	Short: "Creates a new slack webhook",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 
@@ -58,10 +58,15 @@ var webhookCreateHTTPCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		cfg := &webhook.ConfigHTTP{
-			URL: *whhUrl,
+		cfg := &webhook.ConfigSlack{
+			WebhookURL: *whsUrl,
+			Channel:    *whsChannel,
+			Username:   *whsUsername,
+			IconEmoji:  *whsIconEmoji,
+			IconUrl:    *whsIconUrl,
+			Template:   *whsTemplate,
 		}
-		wh, err := webhook.NewWebhook(info.Address.Hash(), evt, webhook.TypeHTTP, cfg)
+		wh, err := webhook.NewWebhook(info.Address.Hash(), evt, webhook.TypeSlack, cfg)
 		if err != nil {
 			logrus.Fatal("Cannot create webhook")
 			os.Exit(1)
@@ -83,12 +88,24 @@ var webhookCreateHTTPCmd = &cobra.Command{
 	},
 }
 
-var whhUrl *string
+var (
+	whsUrl       *string
+	whsChannel   *string
+	whsUsername  *string
+	whsIconEmoji *string
+	whsIconUrl   *string
+	whsTemplate  *string
+)
 
 func init() {
-	webhookCreateCmd.AddCommand(webhookCreateHTTPCmd)
+	webhookCreateCmd.AddCommand(webhookCreateSlackCmd)
 
-	whhUrl = webhookCreateHTTPCmd.Flags().String("url", "", "HTTP webhook URL to send POST to")
+	whsUrl = webhookCreateSlackCmd.Flags().String("url", "", "Slack webhook URL")
+	whsChannel = webhookCreateSlackCmd.Flags().String("channel", "", "Optional channel to post to")
+	whsUsername = webhookCreateSlackCmd.Flags().String("username", "", "Optional username to post from")
+	whsIconEmoji = webhookCreateSlackCmd.Flags().String("icon_emoji", "", "Optional bot icon emoji")
+	whsIconUrl = webhookCreateSlackCmd.Flags().String("icon_url", "", "Optional bot icon url")
+	whsTemplate = webhookCreateSlackCmd.Flags().String("template", "", "Optional text/template")
 
-	_ = webhookCreateHTTPCmd.MarkFlagRequired("url")
+	_ = webhookCreateSlackCmd.MarkFlagRequired("url")
 }

--- a/cmd/bm-client/cmd/webhook_create_slack.go
+++ b/cmd/bm-client/cmd/webhook_create_slack.go
@@ -59,11 +59,11 @@ var webhookCreateSlackCmd = &cobra.Command{
 		}
 
 		cfg := &webhook.ConfigSlack{
-			WebhookURL: *whsUrl,
+			WebhookURL: *whsURL,
 			Channel:    *whsChannel,
 			Username:   *whsUsername,
 			IconEmoji:  *whsIconEmoji,
-			IconUrl:    *whsIconUrl,
+			IconURL:    *whsIconURL,
 			Template:   *whsTemplate,
 		}
 		wh, err := webhook.NewWebhook(info.Address.Hash(), evt, webhook.TypeSlack, cfg)
@@ -84,27 +84,27 @@ var webhookCreateSlackCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		fmt.Println("Created webhook %s", wh.ID)
+		fmt.Printf("Created webhook %s\n", wh.ID)
 	},
 }
 
 var (
-	whsUrl       *string
+	whsURL       *string
 	whsChannel   *string
 	whsUsername  *string
 	whsIconEmoji *string
-	whsIconUrl   *string
+	whsIconURL   *string
 	whsTemplate  *string
 )
 
 func init() {
 	webhookCreateCmd.AddCommand(webhookCreateSlackCmd)
 
-	whsUrl = webhookCreateSlackCmd.Flags().String("url", "", "Slack webhook URL")
+	whsURL = webhookCreateSlackCmd.Flags().String("url", "", "Slack webhook URL")
 	whsChannel = webhookCreateSlackCmd.Flags().String("channel", "", "Optional channel to post to")
 	whsUsername = webhookCreateSlackCmd.Flags().String("username", "", "Optional username to post from")
 	whsIconEmoji = webhookCreateSlackCmd.Flags().String("icon_emoji", "", "Optional bot icon emoji")
-	whsIconUrl = webhookCreateSlackCmd.Flags().String("icon_url", "", "Optional bot icon url")
+	whsIconURL = webhookCreateSlackCmd.Flags().String("icon_url", "", "Optional bot icon url")
 	whsTemplate = webhookCreateSlackCmd.Flags().String("template", "", "Optional text/template")
 
 	_ = webhookCreateSlackCmd.MarkFlagRequired("url")

--- a/cmd/bm-client/cmd/webhook_disable.go
+++ b/cmd/bm-client/cmd/webhook_disable.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal"
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal/container"
+	"github.com/bitmaelum/bitmaelum-suite/internal/api"
+	"github.com/bitmaelum/bitmaelum-suite/internal/vault"
+	"github.com/sirupsen/logrus"
+
+	"github.com/spf13/cobra"
+)
+
+var webhookDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable webhook",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		v := vault.OpenVault()
+		info := vault.GetAccountOrDefault(v, *whAccount)
+
+		resolver := container.Instance.GetResolveService()
+		routingInfo, err := resolver.ResolveRouting(info.RoutingID)
+		if err != nil {
+			logrus.Fatal("Cannot find routing ID for this account")
+			os.Exit(1)
+		}
+
+		client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
+		if err != nil {
+			logrus.Fatal(err)
+			os.Exit(1)
+		}
+
+		err = client.DisableWebhook(info.Address.Hash(), *whdID)
+		if err != nil {
+			logrus.Fatal("cannot disable webhook: ", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("Webhook is disabled")
+	},
+}
+
+var whdID *string
+
+func init() {
+	whdID = webhookDisableCmd.Flags().String("id", "", "webhook ID to disable")
+
+	webhookCmd.AddCommand(webhookDisableCmd)
+}

--- a/cmd/bm-client/cmd/webhook_edit.go
+++ b/cmd/bm-client/cmd/webhook_edit.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal"
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal/container"
+	pkgInternal "github.com/bitmaelum/bitmaelum-suite/internal"
+	"github.com/bitmaelum/bitmaelum-suite/internal/api"
+	"github.com/bitmaelum/bitmaelum-suite/internal/vault"
+	"github.com/sirupsen/logrus"
+
+	"github.com/spf13/cobra"
+)
+
+var webhookEditCmd = &cobra.Command{
+	Use:   "edit",
+	Short: "Edit webhook",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		v := vault.OpenVault()
+		info := vault.GetAccountOrDefault(v, *whAccount)
+
+		resolver := container.Instance.GetResolveService()
+		routingInfo, err := resolver.ResolveRouting(info.RoutingID)
+		if err != nil {
+			logrus.Fatal("Cannot find routing ID for this account")
+			os.Exit(1)
+		}
+
+		client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
+		if err != nil {
+			logrus.Fatal(err)
+			os.Exit(1)
+		}
+
+		// Get webhook and edit
+		src, err := client.GetWebhook(info.Address.Hash(), *wheditID)
+		if err != nil {
+			logrus.Fatal("error while editing webhook: ", err)
+			os.Exit(1)
+		}
+
+		// Unmarshal src-config for editing
+		var srcConfig interface{}
+		err = json.Unmarshal([]byte(src.Config), &srcConfig)
+		if err != nil {
+			logrus.Fatal("error while editing webhook: ", err)
+			os.Exit(1)
+		}
+
+		// Edit into dstConig
+		var dstConfig interface{}
+		err = pkgInternal.OpenJSONFileEditor(srcConfig, &dstConfig)
+		if err != nil {
+			logrus.Fatal("error while editing webhook: ", err)
+			os.Exit(1)
+		}
+
+		// Marshal dstconfig back into src config
+		data, err := json.Marshal(dstConfig)
+		if err != nil {
+			logrus.Fatal("error while editing webhook: ", err)
+			os.Exit(1)
+		}
+		src.Config = string(data)
+
+		// And update webhook
+		err = client.UpdateWebhook(info.Address.Hash(), *wheditID, *src)
+		if err != nil {
+			logrus.Fatal("cannot update webhook: ", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var wheditID *string
+
+func init() {
+	wheditID = webhookEditCmd.Flags().String("id", "", "webhook ID to edit")
+
+	webhookCmd.AddCommand(webhookEditCmd)
+}

--- a/cmd/bm-client/cmd/webhook_enable.go
+++ b/cmd/bm-client/cmd/webhook_enable.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal"
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal/container"
+	"github.com/bitmaelum/bitmaelum-suite/internal/api"
+	"github.com/bitmaelum/bitmaelum-suite/internal/vault"
+	"github.com/sirupsen/logrus"
+
+	"github.com/spf13/cobra"
+)
+
+var webhookEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable webhook",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		v := vault.OpenVault()
+		info := vault.GetAccountOrDefault(v, *whAccount)
+
+		resolver := container.Instance.GetResolveService()
+		routingInfo, err := resolver.ResolveRouting(info.RoutingID)
+		if err != nil {
+			logrus.Fatal("Cannot find routing ID for this account")
+			os.Exit(1)
+		}
+
+		client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
+		if err != nil {
+			logrus.Fatal(err)
+			os.Exit(1)
+		}
+
+		err = client.EnableWebhook(info.Address.Hash(), *wheID)
+		if err != nil {
+			logrus.Fatal("cannot enable webhook: ", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("Webhook is enabled")
+	},
+}
+
+var wheID *string
+
+func init() {
+	wheID = webhookEnableCmd.Flags().String("id", "", "webhook ID to enable")
+
+	webhookCmd.AddCommand(webhookEnableCmd)
+}

--- a/cmd/bm-client/cmd/webhook_list.go
+++ b/cmd/bm-client/cmd/webhook_list.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal"
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-client/internal/container"
+	"github.com/bitmaelum/bitmaelum-suite/internal/api"
+	"github.com/bitmaelum/bitmaelum-suite/internal/vault"
+	"github.com/olekukonko/tablewriter"
+	"github.com/sirupsen/logrus"
+
+	"github.com/spf13/cobra"
+)
+
+var webhookListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Display all webhooks for this account on the server",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		v := vault.OpenVault()
+		info := vault.GetAccountOrDefault(v, *whAccount)
+
+		resolver := container.Instance.GetResolveService()
+		routingInfo, err := resolver.ResolveRouting(info.RoutingID)
+		if err != nil {
+			logrus.Fatal("Cannot find routing ID for this account")
+			os.Exit(1)
+		}
+
+		client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
+		if err != nil {
+			logrus.Fatal(err)
+			os.Exit(1)
+		}
+
+		webhooks, err := client.ListWebhooks(info.Address.Hash())
+		if err != nil {
+			logrus.Fatal("cannot fetch webhooks: ", err)
+			os.Exit(1)
+		}
+
+		if len(webhooks) == 0 {
+			fmt.Println("No webhooks are found for this account")
+			return
+		}
+
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetHeader([]string{"ID", "Event", "Type", "Enabled"})
+
+		for _, wh := range webhooks {
+			enabled := "-"
+			if wh.Enabled {
+				enabled = "enabled"
+			}
+
+			table.Append([]string{
+				wh.ID,
+				wh.Event.String(),
+				wh.Type.String(),
+				enabled,
+			})
+		}
+
+		table.Render()
+	},
+}
+
+func init() {
+	webhookCmd.AddCommand(webhookListCmd)
+}

--- a/cmd/bm-client/handlers/list_messages.go
+++ b/cmd/bm-client/handlers/list_messages.go
@@ -38,7 +38,7 @@ import (
 )
 
 // ListMessages will display message information from accounts and boxes
-func ListMessages(accounts []vault.AccountInfo, since time.Time) {
+func ListMessages(accounts []vault.AccountInfo, since time.Time) int {
 	table := tablewriter.NewWriter(os.Stdout)
 	// table.SetAutoMergeCells(true)
 
@@ -47,7 +47,7 @@ func ListMessages(accounts []vault.AccountInfo, since time.Time) {
 
 	msgCount := 0
 
-	fmt.Print("* Fetching remote messages...")
+	fmt.Print("* Fetching messages from remote server(s)...")
 	for _, info := range accounts {
 		// Fetch routing info
 		resolver := container.Instance.GetResolveService()
@@ -65,11 +65,11 @@ func ListMessages(accounts []vault.AccountInfo, since time.Time) {
 	}
 	fmt.Println("")
 
-	if msgCount == 0 {
-		fmt.Println("* No messages in the given timespan")
-	} else {
+	if msgCount > 0 {
 		table.Render()
 	}
+
+	return msgCount
 }
 
 var firstRender bool

--- a/cmd/bm-client/handlers/read_message.go
+++ b/cmd/bm-client/handlers/read_message.go
@@ -56,7 +56,7 @@ func ReadMessages(info *vault.AccountInfo, routingInfo *resolver.RoutingInfo, bo
 	}
 
 	// generate a message list of all messages we want do display
-	fmt.Print("* Fetching remote messages...")
+	fmt.Print("* Fetching messages from remote server(s)...")
 	entryList := queryMessageEntries(client, info, box, messageID, since)
 	idx := 0
 	fmt.Println("")

--- a/cmd/bm-server/handler/account.go
+++ b/cmd/bm-server/handler/account.go
@@ -120,7 +120,6 @@ func CreateAccount(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-
 	httputils.JSONOut(w, http.StatusCreated, httputils.StatusOk("BitMaelum account has been successfully created."))
 }
 

--- a/cmd/bm-server/handler/account.go
+++ b/cmd/bm-server/handler/account.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/container"
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/httputils"
 	"github.com/bitmaelum/bitmaelum-suite/internal/config"
 	"github.com/bitmaelum/bitmaelum-suite/internal/signature"
 	"github.com/bitmaelum/bitmaelum-suite/pkg/bmcrypto"
@@ -45,36 +46,36 @@ type inputCreateAccount struct {
 // CreateAccount will create a new account
 func CreateAccount(w http.ResponseWriter, req *http.Request) {
 	var input inputCreateAccount
-	err := DecodeBody(w, req.Body, &input)
+	err := httputils.DecodeBody(w, req.Body, &input)
 	if err != nil {
 		return
 	}
 
 	// Check proof of work first
 	if input.ProofOfWork.Bits < config.Server.Accounts.ProofOfWork {
-		ErrorOut(w, http.StatusBadRequest, fmt.Sprintf("Proof of work must be at least %d bits", config.Server.Accounts.ProofOfWork))
+		httputils.ErrorOut(w, http.StatusBadRequest, fmt.Sprintf("Proof of work must be at least %d bits", config.Server.Accounts.ProofOfWork))
 		return
 	}
 
 	work := pow.New(input.ProofOfWork.Bits, input.Addr.String(), input.ProofOfWork.Proof)
 	if !work.IsValid() {
-		ErrorOut(w, http.StatusBadRequest, "incorrect proof of work")
+		httputils.ErrorOut(w, http.StatusBadRequest, "incorrect proof of work")
 		return
 	}
 
 	// Check if the user+org matches our actual hash address
 	userHash, err := hash.NewFromHash(input.UserHash)
 	if err != nil {
-		ErrorOut(w, http.StatusBadRequest, "invalid body: user_hash")
+		httputils.ErrorOut(w, http.StatusBadRequest, "invalid body: user_hash")
 		return
 	}
 	orgHash, err := hash.NewFromHash(input.OrgHash)
 	if err != nil {
-		ErrorOut(w, http.StatusBadRequest, "invalid body: org_hash")
+		httputils.ErrorOut(w, http.StatusBadRequest, "invalid body: org_hash")
 		return
 	}
 	if !input.Addr.Verify(*userHash, *orgHash) {
-		ErrorOut(w, http.StatusBadRequest, "cant verify the address hashes")
+		httputils.ErrorOut(w, http.StatusBadRequest, "cant verify the address hashes")
 		return
 	}
 
@@ -84,12 +85,12 @@ func CreateAccount(w http.ResponseWriter, req *http.Request) {
 		r := container.Instance.GetResolveService()
 		oh, err := hash.NewFromHash(input.OrgHash)
 		if err != nil {
-			ErrorOut(w, http.StatusBadRequest, "incorrect org hash")
+			httputils.ErrorOut(w, http.StatusBadRequest, "incorrect org hash")
 			return
 		}
 		oi, err := r.ResolveOrganisation(*oh)
 		if err != nil {
-			ErrorOut(w, http.StatusBadRequest, "cannot find organisation")
+			httputils.ErrorOut(w, http.StatusBadRequest, "cannot find organisation")
 			return
 		}
 
@@ -100,14 +101,14 @@ func CreateAccount(w http.ResponseWriter, req *http.Request) {
 	// Verify token
 	it, err := signature.ParseInviteToken(input.Token)
 	if err != nil || !it.Verify(config.Routing.RoutingID, pubKey) {
-		ErrorOut(w, http.StatusBadRequest, "cannot validate token")
+		httputils.ErrorOut(w, http.StatusBadRequest, "cannot validate token")
 		return
 	}
 
 	// Check if account exists
 	ar := container.Instance.GetAccountRepo()
 	if ar.Exists(input.Addr) {
-		ErrorOut(w, http.StatusBadRequest, "account already exists")
+		httputils.ErrorOut(w, http.StatusBadRequest, "account already exists")
 		return
 	}
 
@@ -115,62 +116,62 @@ func CreateAccount(w http.ResponseWriter, req *http.Request) {
 	err = ar.Create(input.Addr, input.PublicKey)
 	if err != nil {
 		logrus.Error(err)
-		ErrorOut(w, http.StatusInternalServerError, "cannot create account")
+		httputils.ErrorOut(w, http.StatusInternalServerError, "cannot create account")
 		return
 	}
 
 
-	JSONOut(w, http.StatusCreated, StatusOk("BitMaelum account has been successfully created."))
+	httputils.JSONOut(w, http.StatusCreated, httputils.StatusOk("BitMaelum account has been successfully created."))
 }
 
 // RetrieveOrganisation is the handler that will retrieve organisation settings
 func RetrieveOrganisation(w http.ResponseWriter, req *http.Request) {
 	haddr, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		ErrorOut(w, http.StatusBadRequest, "incorrect address")
+		httputils.ErrorOut(w, http.StatusBadRequest, "incorrect address")
 		return
 	}
 
 	// Check if account exists
 	ar := container.Instance.GetAccountRepo()
 	if !ar.Exists(*haddr) {
-		ErrorOut(w, http.StatusNotFound, "address not found")
+		httputils.ErrorOut(w, http.StatusNotFound, "address not found")
 		return
 	}
 
 	settings, err := ar.FetchOrganisationSettings(*haddr)
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, "organisation settings not found")
+		httputils.ErrorOut(w, http.StatusNotFound, "organisation settings not found")
 		return
 	}
 
 	// Return public keys
-	JSONOut(w, http.StatusOK, settings)
+	httputils.JSONOut(w, http.StatusOK, settings)
 }
 
 // RetrieveKeys is the handler that will retrieve public keys directly from the mail server
 func RetrieveKeys(w http.ResponseWriter, req *http.Request) {
 	haddr, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		ErrorOut(w, http.StatusBadRequest, "incorrect address")
+		httputils.ErrorOut(w, http.StatusBadRequest, "incorrect address")
 		return
 	}
 
 	// Check if account exists
 	ar := container.Instance.GetAccountRepo()
 	if !ar.Exists(*haddr) {
-		ErrorOut(w, http.StatusNotFound, "public keys not found")
+		httputils.ErrorOut(w, http.StatusNotFound, "public keys not found")
 		return
 	}
 
 	keys, err := ar.FetchKeys(*haddr)
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, "public keys not found")
+		httputils.ErrorOut(w, http.StatusNotFound, "public keys not found")
 		return
 	}
 
 	// Return public keys
-	_ = JSONOut(w, http.StatusOK, jsonOut{
+	_ = httputils.JSONOut(w, http.StatusOK, jsonOut{
 		"public_keys": keys,
 	})
 }

--- a/cmd/bm-server/handler/account.go
+++ b/cmd/bm-server/handler/account.go
@@ -20,7 +20,6 @@
 package handler
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -120,9 +119,8 @@ func CreateAccount(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(StatusOk("BitMaelum account has been successfully created."))
+
+	JSONOut(w, http.StatusCreated, StatusOk("BitMaelum account has been successfully created."))
 }
 
 // RetrieveOrganisation is the handler that will retrieve organisation settings
@@ -147,9 +145,7 @@ func RetrieveOrganisation(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Return public keys
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(settings)
+	JSONOut(w, http.StatusOK, settings)
 }
 
 // RetrieveKeys is the handler that will retrieve public keys directly from the mail server
@@ -174,9 +170,7 @@ func RetrieveKeys(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Return public keys
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(jsonOut{
+	_ = JSONOut(w, http.StatusOK, jsonOut{
 		"public_keys": keys,
 	})
 }

--- a/cmd/bm-server/handler/api_key.go
+++ b/cmd/bm-server/handler/api_key.go
@@ -20,7 +20,6 @@
 package handler
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -72,9 +71,7 @@ func CreateAPIKey(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Output key
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(jsonOut{
+	_ = JSONOut(w, http.StatusCreated, jsonOut{
 		"api_key": newAPIKey.ID,
 	})
 }
@@ -97,9 +94,7 @@ func ListAPIKeys(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Output key
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(keys)
+	_ = JSONOut(w, http.StatusOK, keys)
 }
 
 // DeleteAPIKey will remove a key
@@ -124,8 +119,7 @@ func DeleteAPIKey(w http.ResponseWriter, req *http.Request) {
 	_ = repo.Remove(*k)
 
 	// All is well
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	_ = JSONOut(w, http.StatusNoContent, "")
 }
 
 // GetAPIKeyDetails will get a key
@@ -147,7 +141,5 @@ func GetAPIKeyDetails(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Output key
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(k)
+	_ = JSONOut(w, http.StatusOK, k)
 }

--- a/cmd/bm-server/handler/api_key.go
+++ b/cmd/bm-server/handler/api_key.go
@@ -77,7 +77,7 @@ func CreateAPIKey(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	_ = dispatcher.DispatchApiKeyCreate(*h, newAPIKey)
+	_ = dispatcher.DispatchAPIKeyCreate(*h, newAPIKey)
 
 	// Output key
 	_ = httputils.JSONOut(w, http.StatusCreated, jsonOut{
@@ -116,7 +116,7 @@ func DeleteAPIKey(w http.ResponseWriter, req *http.Request) {
 	repo := container.Instance.GetAPIKeyRepo()
 	_ = repo.Remove(*k)
 
-	_ = dispatcher.DispatchApiKeyDelete(*k.AddressHash, *k)
+	_ = dispatcher.DispatchAPIKeyDelete(*k.AddressHash, *k)
 
 	// All is well
 	_ = httputils.JSONOut(w, http.StatusNoContent, "")

--- a/cmd/bm-server/handler/api_key.go
+++ b/cmd/bm-server/handler/api_key.go
@@ -37,7 +37,6 @@ var (
 	errAPIKeyNotFound = errors.New("api key not found")
 )
 
-
 type inputAPIKeyType struct {
 	Permissions []string `json:"permissions"`
 	Expires     int64    `json:"expires,omitempty"`

--- a/cmd/bm-server/handler/api_key.go
+++ b/cmd/bm-server/handler/api_key.go
@@ -28,6 +28,7 @@ import (
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/httputils"
 	"github.com/bitmaelum/bitmaelum-suite/internal"
 	"github.com/bitmaelum/bitmaelum-suite/internal/container"
+	"github.com/bitmaelum/bitmaelum-suite/internal/dispatcher"
 	"github.com/bitmaelum/bitmaelum-suite/internal/key"
 	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
 	"github.com/gorilla/mux"
@@ -76,6 +77,8 @@ func CreateAPIKey(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	_ = dispatcher.DispatchApiKeyCreate(*h, newAPIKey)
+
 	// Output key
 	_ = httputils.JSONOut(w, http.StatusCreated, jsonOut{
 		"api_key": newAPIKey.ID,
@@ -112,6 +115,8 @@ func DeleteAPIKey(w http.ResponseWriter, req *http.Request) {
 
 	repo := container.Instance.GetAPIKeyRepo()
 	_ = repo.Remove(*k)
+
+	_ = dispatcher.DispatchApiKeyDelete(*k.AddressHash, *k)
 
 	// All is well
 	_ = httputils.JSONOut(w, http.StatusNoContent, "")

--- a/cmd/bm-server/handler/api_key.go
+++ b/cmd/bm-server/handler/api_key.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/httputils"
 	"github.com/bitmaelum/bitmaelum-suite/internal"
 	"github.com/bitmaelum/bitmaelum-suite/internal/container"
 	"github.com/bitmaelum/bitmaelum-suite/internal/key"
@@ -40,22 +41,22 @@ type inputAPIKeyType struct {
 // CreateAPIKey is a handler that will create a new API key (non-admin keys only)
 func CreateAPIKey(w http.ResponseWriter, req *http.Request) {
 	var input inputAPIKeyType
-	err := DecodeBody(w, req.Body, &input)
+	err := httputils.DecodeBody(w, req.Body, &input)
 	if err != nil {
-		ErrorOut(w, http.StatusBadRequest, "incorrect body")
+		httputils.ErrorOut(w, http.StatusBadRequest, "incorrect body")
 		return
 	}
 
 	//
 	err = internal.CheckAccountPermissions(input.Permissions)
 	if err != nil {
-		ErrorOut(w, http.StatusBadRequest, "incorrect permissions")
+		httputils.ErrorOut(w, http.StatusBadRequest, "incorrect permissions")
 		return
 	}
 
 	h, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
 		return
 	}
 
@@ -66,12 +67,12 @@ func CreateAPIKey(w http.ResponseWriter, req *http.Request) {
 	err = repo.Store(newAPIKey)
 	if err != nil {
 		msg := fmt.Sprintf("error while storing key: %s", err)
-		ErrorOut(w, http.StatusInternalServerError, msg)
+		httputils.ErrorOut(w, http.StatusInternalServerError, msg)
 		return
 	}
 
 	// Output key
-	_ = JSONOut(w, http.StatusCreated, jsonOut{
+	_ = httputils.JSONOut(w, http.StatusCreated, jsonOut{
 		"api_key": newAPIKey.ID,
 	})
 }
@@ -80,7 +81,7 @@ func CreateAPIKey(w http.ResponseWriter, req *http.Request) {
 func ListAPIKeys(w http.ResponseWriter, req *http.Request) {
 	h, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
 		return
 	}
 
@@ -89,19 +90,19 @@ func ListAPIKeys(w http.ResponseWriter, req *http.Request) {
 	keys, err := repo.FetchByHash(h.String())
 	if err != nil {
 		msg := fmt.Sprintf("error while retrieving keys: %s", err)
-		ErrorOut(w, http.StatusInternalServerError, msg)
+		httputils.ErrorOut(w, http.StatusInternalServerError, msg)
 		return
 	}
 
 	// Output key
-	_ = JSONOut(w, http.StatusOK, keys)
+	_ = httputils.JSONOut(w, http.StatusOK, keys)
 }
 
 // DeleteAPIKey will remove a key
 func DeleteAPIKey(w http.ResponseWriter, req *http.Request) {
 	h, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
 		return
 	}
 
@@ -112,21 +113,21 @@ func DeleteAPIKey(w http.ResponseWriter, req *http.Request) {
 	k, err := repo.Fetch(keyID)
 	if err != nil || k.AddressHash.String() != h.String() {
 		// Only allow deleting of keys that we own as account
-		ErrorOut(w, http.StatusNotFound, "key not found")
+		httputils.ErrorOut(w, http.StatusNotFound, "key not found")
 		return
 	}
 
 	_ = repo.Remove(*k)
 
 	// All is well
-	_ = JSONOut(w, http.StatusNoContent, "")
+	_ = httputils.JSONOut(w, http.StatusNoContent, "")
 }
 
 // GetAPIKeyDetails will get a key
 func GetAPIKeyDetails(w http.ResponseWriter, req *http.Request) {
 	h, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
 		return
 	}
 
@@ -136,10 +137,10 @@ func GetAPIKeyDetails(w http.ResponseWriter, req *http.Request) {
 	repo := container.Instance.GetAPIKeyRepo()
 	k, err := repo.Fetch(keyID)
 	if err != nil || k.AddressHash.String() != h.String() {
-		ErrorOut(w, http.StatusNotFound, "key not found")
+		httputils.ErrorOut(w, http.StatusNotFound, "key not found")
 		return
 	}
 
 	// Output key
-	_ = JSONOut(w, http.StatusOK, k)
+	_ = httputils.JSONOut(w, http.StatusOK, k)
 }

--- a/cmd/bm-server/handler/api_key.go
+++ b/cmd/bm-server/handler/api_key.go
@@ -20,6 +20,7 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -31,6 +32,11 @@ import (
 	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
 	"github.com/gorilla/mux"
 )
+
+var (
+	errAPIKeyNotFound = errors.New("api key not found")
+)
+
 
 type inputAPIKeyType struct {
 	Permissions []string `json:"permissions"`
@@ -100,23 +106,12 @@ func ListAPIKeys(w http.ResponseWriter, req *http.Request) {
 
 // DeleteAPIKey will remove a key
 func DeleteAPIKey(w http.ResponseWriter, req *http.Request) {
-	h, err := hash.NewFromHash(mux.Vars(req)["addr"])
+	k, err := hasAPIwebKeyAccess(w, req)
 	if err != nil {
-		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
 		return
 	}
 
-	keyID := mux.Vars(req)["key"]
-
-	// Fetch key
 	repo := container.Instance.GetAPIKeyRepo()
-	k, err := repo.Fetch(keyID)
-	if err != nil || k.AddressHash.String() != h.String() {
-		// Only allow deleting of keys that we own as account
-		httputils.ErrorOut(w, http.StatusNotFound, "key not found")
-		return
-	}
-
 	_ = repo.Remove(*k)
 
 	// All is well
@@ -125,10 +120,20 @@ func DeleteAPIKey(w http.ResponseWriter, req *http.Request) {
 
 // GetAPIKeyDetails will get a key
 func GetAPIKeyDetails(w http.ResponseWriter, req *http.Request) {
+	k, err := hasAPIwebKeyAccess(w, req)
+	if err != nil {
+		return
+	}
+
+	// Output key
+	_ = httputils.JSONOut(w, http.StatusOK, k)
+}
+
+func hasAPIwebKeyAccess(w http.ResponseWriter, req *http.Request) (*key.APIKeyType, error) {
 	h, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
-		return
+		httputils.ErrorOut(w, http.StatusNotFound, errAccountNotFound.Error())
+		return nil, errAccountNotFound
 	}
 
 	keyID := mux.Vars(req)["key"]
@@ -137,10 +142,9 @@ func GetAPIKeyDetails(w http.ResponseWriter, req *http.Request) {
 	repo := container.Instance.GetAPIKeyRepo()
 	k, err := repo.Fetch(keyID)
 	if err != nil || k.AddressHash.String() != h.String() {
-		httputils.ErrorOut(w, http.StatusNotFound, "key not found")
-		return
+		httputils.ErrorOut(w, http.StatusNotFound, errAPIKeyNotFound.Error())
+		return nil, errAPIKeyNotFound
 	}
 
-	// Output key
-	_ = httputils.JSONOut(w, http.StatusOK, k)
+	return k, nil
 }

--- a/cmd/bm-server/handler/auth_key.go
+++ b/cmd/bm-server/handler/auth_key.go
@@ -20,7 +20,6 @@
 package handler
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -68,9 +67,7 @@ func CreateAuthKey(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Output key
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(jsonOut{
+	_ = JSONOut(w, http.StatusCreated, jsonOut{
 		"auth_key": newAuthKey.Fingerprint,
 	})
 }
@@ -93,9 +90,7 @@ func ListAuthKeys(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Output key
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(keys)
+	_ = JSONOut(w, http.StatusOK, keys)
 }
 
 // DeleteAuthKey will remove a key
@@ -120,8 +115,7 @@ func DeleteAuthKey(w http.ResponseWriter, req *http.Request) {
 	_ = repo.Remove(*k)
 
 	// All is well
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	_ = JSONOut(w, http.StatusNoContent, "")
 }
 
 // GetAuthKeyDetails will get a key
@@ -143,7 +137,5 @@ func GetAuthKeyDetails(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Output key
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(k)
+	_ = JSONOut(w, http.StatusOK, k)
 }

--- a/cmd/bm-server/handler/auth_key.go
+++ b/cmd/bm-server/handler/auth_key.go
@@ -37,7 +37,6 @@ var (
 	errAuthKeyNotFound = errors.New("auth key not found")
 )
 
-
 type inputAuthKeyType struct {
 	Fingerprint string           `json:"fingerprint"`
 	PublicKey   *bmcrypto.PubKey `json:"public_key"`
@@ -105,7 +104,6 @@ func DeleteAuthKey(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		return
 	}
-
 
 	repo := container.Instance.GetAuthKeyRepo()
 	_ = repo.Remove(*k)

--- a/cmd/bm-server/handler/auth_key.go
+++ b/cmd/bm-server/handler/auth_key.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/httputils"
 	"github.com/bitmaelum/bitmaelum-suite/internal/container"
 	"github.com/bitmaelum/bitmaelum-suite/internal/key"
 	"github.com/bitmaelum/bitmaelum-suite/pkg/bmcrypto"
@@ -42,16 +43,16 @@ type inputAuthKeyType struct {
 // CreateAuthKey is a handler that will create a new auth key
 func CreateAuthKey(w http.ResponseWriter, req *http.Request) {
 	var input inputAuthKeyType
-	err := DecodeBody(w, req.Body, &input)
+	err := httputils.DecodeBody(w, req.Body, &input)
 	if err != nil {
-		ErrorOut(w, http.StatusBadRequest, "incorrect body")
+		httputils.ErrorOut(w, http.StatusBadRequest, "incorrect body")
 		return
 	}
 
 	//
 	h, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
 		return
 	}
 
@@ -62,12 +63,12 @@ func CreateAuthKey(w http.ResponseWriter, req *http.Request) {
 	err = repo.Store(newAuthKey)
 	if err != nil {
 		msg := fmt.Sprintf("error while storing key: %s", err)
-		ErrorOut(w, http.StatusInternalServerError, msg)
+		httputils.ErrorOut(w, http.StatusInternalServerError, msg)
 		return
 	}
 
 	// Output key
-	_ = JSONOut(w, http.StatusCreated, jsonOut{
+	_ = httputils.JSONOut(w, http.StatusCreated, jsonOut{
 		"auth_key": newAuthKey.Fingerprint,
 	})
 }
@@ -76,7 +77,7 @@ func CreateAuthKey(w http.ResponseWriter, req *http.Request) {
 func ListAuthKeys(w http.ResponseWriter, req *http.Request) {
 	h, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
 		return
 	}
 
@@ -85,19 +86,19 @@ func ListAuthKeys(w http.ResponseWriter, req *http.Request) {
 	keys, err := repo.FetchByHash(h.String())
 	if err != nil {
 		msg := fmt.Sprintf("error while retrieving keys: %s", err)
-		ErrorOut(w, http.StatusInternalServerError, msg)
+		httputils.ErrorOut(w, http.StatusInternalServerError, msg)
 		return
 	}
 
 	// Output key
-	_ = JSONOut(w, http.StatusOK, keys)
+	_ = httputils.JSONOut(w, http.StatusOK, keys)
 }
 
 // DeleteAuthKey will remove a key
 func DeleteAuthKey(w http.ResponseWriter, req *http.Request) {
 	h, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
 		return
 	}
 
@@ -108,21 +109,21 @@ func DeleteAuthKey(w http.ResponseWriter, req *http.Request) {
 	k, err := repo.Fetch(keyID)
 	if err != nil || k.AddressHash.String() != h.String() {
 		// Only allow deleting of keys that we own as account
-		ErrorOut(w, http.StatusNotFound, "key not found")
+		httputils.ErrorOut(w, http.StatusNotFound, "key not found")
 		return
 	}
 
 	_ = repo.Remove(*k)
 
 	// All is well
-	_ = JSONOut(w, http.StatusNoContent, "")
+	_ = httputils.JSONOut(w, http.StatusNoContent, "")
 }
 
 // GetAuthKeyDetails will get a key
 func GetAuthKeyDetails(w http.ResponseWriter, req *http.Request) {
 	h, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
 		return
 	}
 
@@ -132,10 +133,10 @@ func GetAuthKeyDetails(w http.ResponseWriter, req *http.Request) {
 	repo := container.Instance.GetAuthKeyRepo()
 	k, err := repo.Fetch(keyID)
 	if err != nil || k.AddressHash.String() != h.String() {
-		ErrorOut(w, http.StatusNotFound, "key not found")
+		httputils.ErrorOut(w, http.StatusNotFound, "key not found")
 		return
 	}
 
 	// Output key
-	_ = JSONOut(w, http.StatusOK, k)
+	_ = httputils.JSONOut(w, http.StatusOK, k)
 }

--- a/cmd/bm-server/handler/auth_key.go
+++ b/cmd/bm-server/handler/auth_key.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/httputils"
 	"github.com/bitmaelum/bitmaelum-suite/internal/container"
+	"github.com/bitmaelum/bitmaelum-suite/internal/dispatcher"
 	"github.com/bitmaelum/bitmaelum-suite/internal/key"
 	"github.com/bitmaelum/bitmaelum-suite/pkg/bmcrypto"
 	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
@@ -72,6 +73,8 @@ func CreateAuthKey(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	_ = dispatcher.DispatchAuthKeyCreate(*h, newAuthKey)
+
 	// Output key
 	_ = httputils.JSONOut(w, http.StatusCreated, jsonOut{
 		"auth_key": newAuthKey.Fingerprint,
@@ -107,6 +110,8 @@ func DeleteAuthKey(w http.ResponseWriter, req *http.Request) {
 
 	repo := container.Instance.GetAuthKeyRepo()
 	_ = repo.Remove(*k)
+
+	_ = dispatcher.DispatchAuthKeyDelete(k.AddressHash, *k)
 
 	// All is well
 	_ = httputils.JSONOut(w, http.StatusNoContent, "")

--- a/cmd/bm-server/handler/boxes.go
+++ b/cmd/bm-server/handler/boxes.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/account"
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/container"
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/httputils"
 	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
 	"github.com/gorilla/mux"
 )
@@ -44,56 +45,56 @@ const (
 func CreateBox(w http.ResponseWriter, req *http.Request) {
 	haddr, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
 		return
 	}
 
 	var input boxIn
-	err = DecodeBody(w, req.Body, &input)
+	err = httputils.DecodeBody(w, req.Body, &input)
 	if err != nil {
-		ErrorOut(w, http.StatusBadRequest, err.Error())
+		httputils.ErrorOut(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
 	ar := container.Instance.GetAccountRepo()
 	err = ar.CreateBox(*haddr, input.ParentBoxID)
 	if err != nil {
-		ErrorOut(w, http.StatusBadRequest, err.Error())
+		httputils.ErrorOut(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	JSONOut(w, http.StatusCreated, "")
+	httputils.JSONOut(w, http.StatusCreated, "")
 }
 
 // DeleteBox deletes a given box with all messages (note: what about child boxes??)
 func DeleteBox(w http.ResponseWriter, req *http.Request) {
 	haddr, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
 		return
 	}
 
 	box, err := strconv.Atoi(mux.Vars(req)["box"])
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, "box not found")
+		httputils.ErrorOut(w, http.StatusNotFound, "box not found")
 		return
 	}
 
 	ar := container.Instance.GetAccountRepo()
 	err = ar.DeleteBox(*haddr, box)
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, err.Error())
+		httputils.ErrorOut(w, http.StatusNotFound, err.Error())
 		return
 	}
 
-	JSONOut(w, http.StatusNoContent, "")
+	httputils.JSONOut(w, http.StatusNoContent, "")
 }
 
 // RetrieveBoxes retrieves all message boxes for the given account
 func RetrieveBoxes(w http.ResponseWriter, req *http.Request) {
 	haddr, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
 		return
 	}
 
@@ -101,7 +102,7 @@ func RetrieveBoxes(w http.ResponseWriter, req *http.Request) {
 	ar := container.Instance.GetAccountRepo()
 	boxes, err := ar.GetAllBoxes(*haddr)
 	if err != nil {
-		ErrorOut(w, http.StatusInternalServerError, "cannot read boxes")
+		httputils.ErrorOut(w, http.StatusInternalServerError, "cannot read boxes")
 		return
 	}
 
@@ -113,14 +114,14 @@ func RetrieveBoxes(w http.ResponseWriter, req *http.Request) {
 		"boxes": boxes,
 	}
 
-	_ = JSONOut(w, http.StatusOK, output)
+	_ = httputils.JSONOut(w, http.StatusOK, output)
 }
 
 // RetrieveMessagesFromBox retrieves info about the given mailbox
 func RetrieveMessagesFromBox(w http.ResponseWriter, req *http.Request) {
 	list, err := getMessageList(req)
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
 		return
 	}
 
@@ -131,7 +132,7 @@ func RetrieveMessagesFromBox(w http.ResponseWriter, req *http.Request) {
 			ids = append(ids, msg.ID)
 		}
 
-		_ = JSONOut(w, http.StatusOK, jsonOut{
+		_ = httputils.JSONOut(w, http.StatusOK, jsonOut{
 			"meta":        list.Meta,
 			"message_ids": ids,
 		})
@@ -139,7 +140,7 @@ func RetrieveMessagesFromBox(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Otherwise, return the whole list
-	_ = JSONOut(w, http.StatusOK, list)
+	_ = httputils.JSONOut(w, http.StatusOK, list)
 }
 
 func getMessageList(req *http.Request) (*account.MessageList, *httpError) {

--- a/cmd/bm-server/handler/boxes.go
+++ b/cmd/bm-server/handler/boxes.go
@@ -62,8 +62,7 @@ func CreateBox(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
+	JSONOut(w, http.StatusCreated, "")
 }
 
 // DeleteBox deletes a given box with all messages (note: what about child boxes??)
@@ -87,8 +86,7 @@ func DeleteBox(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusNoContent)
+	JSONOut(w, http.StatusNoContent, "")
 }
 
 // RetrieveBoxes retrieves all message boxes for the given account
@@ -115,7 +113,7 @@ func RetrieveBoxes(w http.ResponseWriter, req *http.Request) {
 		"boxes": boxes,
 	}
 
-	_ = JSONOut(w, output)
+	_ = JSONOut(w, http.StatusOK, output)
 }
 
 // RetrieveMessagesFromBox retrieves info about the given mailbox
@@ -133,7 +131,7 @@ func RetrieveMessagesFromBox(w http.ResponseWriter, req *http.Request) {
 			ids = append(ids, msg.ID)
 		}
 
-		_ = JSONOut(w, jsonOut{
+		_ = JSONOut(w, http.StatusOK, jsonOut{
 			"meta":        list.Meta,
 			"message_ids": ids,
 		})
@@ -141,7 +139,7 @@ func RetrieveMessagesFromBox(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Otherwise, return the whole list
-	_ = JSONOut(w, list)
+	_ = JSONOut(w, http.StatusOK, list)
 }
 
 func getMessageList(req *http.Request) (*account.MessageList, *httpError) {

--- a/cmd/bm-server/handler/incoming.go
+++ b/cmd/bm-server/handler/incoming.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/httputils"
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/processor"
 	"github.com/bitmaelum/bitmaelum-suite/internal/container"
 	"github.com/bitmaelum/bitmaelum-suite/internal/message"
@@ -44,38 +45,38 @@ func IncomingMessageHeader(w http.ResponseWriter, req *http.Request) {
 	// Check ticket
 	t, err := fetchTicketHeader(req)
 	if err != nil {
-		ErrorOut(w, http.StatusUnauthorized, invalidTicketID)
+		httputils.ErrorOut(w, http.StatusUnauthorized, invalidTicketID)
 		return
 	}
 
 	// Read header from request body
 	header, err := readHeaderFromBody(req.Body)
 	if err != nil {
-		ErrorOut(w, http.StatusBadRequest, "invalid header posted")
+		httputils.ErrorOut(w, http.StatusBadRequest, "invalid header posted")
 		return
 	}
 
 	// Verify from/to header with the ticket info
 	if header.From.Addr.String() != t.From.String() || header.To.Addr.String() != t.To.String() {
-		ErrorOut(w, http.StatusBadRequest, "header from/to address do not match the ticket")
+		httputils.ErrorOut(w, http.StatusBadRequest, "header from/to address do not match the ticket")
 		return
 	}
 
 	// Add a server signature to the header, so we know this is the origin of the message
 	err = message.SignServerHeader(header)
 	if err != nil {
-		ErrorOut(w, http.StatusInternalServerError, "error while signing incoming message")
+		httputils.ErrorOut(w, http.StatusInternalServerError, "error while signing incoming message")
 		return
 	}
 
 	// Save request
 	err = message.StoreHeader(t.ID, header)
 	if err != nil {
-		ErrorOut(w, http.StatusInternalServerError, "error while storing message header")
+		httputils.ErrorOut(w, http.StatusInternalServerError, "error while storing message header")
 		return
 	}
 
-	_ = JSONOut(w, http.StatusOK, StatusOk("saved message header"))
+	_ = httputils.JSONOut(w, http.StatusOK, httputils.StatusOk("saved message header"))
 }
 
 // IncomingMessageCatalog deals with uploading message catalogs
@@ -83,17 +84,17 @@ func IncomingMessageCatalog(w http.ResponseWriter, req *http.Request) {
 	// Check ticket
 	t, err := fetchTicketHeader(req)
 	if err != nil {
-		ErrorOut(w, http.StatusUnauthorized, invalidTicketID)
+		httputils.ErrorOut(w, http.StatusUnauthorized, invalidTicketID)
 		return
 	}
 
 	err = message.StoreCatalog(t.ID, req.Body)
 	if err != nil {
-		ErrorOut(w, http.StatusInternalServerError, "error while storing message catalog")
+		httputils.ErrorOut(w, http.StatusInternalServerError, "error while storing message catalog")
 		return
 	}
 
-	_ = JSONOut(w, http.StatusOK, StatusOk("saved message catalog"))
+	_ = httputils.JSONOut(w, http.StatusOK, httputils.StatusOk("saved message catalog"))
 }
 
 // IncomingMessageBlock deals with uploading message blocks
@@ -101,7 +102,7 @@ func IncomingMessageBlock(w http.ResponseWriter, req *http.Request) {
 	// Check ticket
 	t, err := fetchTicketHeader(req)
 	if err != nil {
-		ErrorOut(w, http.StatusUnauthorized, invalidTicketID)
+		httputils.ErrorOut(w, http.StatusUnauthorized, invalidTicketID)
 		return
 	}
 
@@ -110,11 +111,11 @@ func IncomingMessageBlock(w http.ResponseWriter, req *http.Request) {
 
 	err = message.StoreBlock(t.ID, messageID, req.Body)
 	if err != nil {
-		ErrorOut(w, http.StatusInternalServerError, "error while storing message block")
+		httputils.ErrorOut(w, http.StatusInternalServerError, "error while storing message block")
 		return
 	}
 
-	_ = JSONOut(w, http.StatusOK, StatusOk("saved message block"))
+	_ = httputils.JSONOut(w, http.StatusOK, httputils.StatusOk("saved message block"))
 }
 
 // IncomingMessageAttachment deals with uploading message attachments
@@ -122,7 +123,7 @@ func IncomingMessageAttachment(w http.ResponseWriter, req *http.Request) {
 	// Check ticket
 	t, err := fetchTicketHeader(req)
 	if err != nil {
-		ErrorOut(w, http.StatusUnauthorized, invalidTicketID)
+		httputils.ErrorOut(w, http.StatusUnauthorized, invalidTicketID)
 		return
 	}
 
@@ -131,11 +132,11 @@ func IncomingMessageAttachment(w http.ResponseWriter, req *http.Request) {
 
 	err = message.StoreAttachment(t.ID, messageID, req.Body)
 	if err != nil {
-		ErrorOut(w, http.StatusInternalServerError, "error while storing message attachment")
+		httputils.ErrorOut(w, http.StatusInternalServerError, "error while storing message attachment")
 		return
 	}
 
-	_ = JSONOut(w, http.StatusOK, StatusOk("saved message attachment"))
+	_ = httputils.JSONOut(w, http.StatusOK, httputils.StatusOk("saved message attachment"))
 }
 
 // CompleteIncoming is called whenever everything from a message has been uploaded and can be actually send
@@ -143,7 +144,7 @@ func CompleteIncoming(w http.ResponseWriter, req *http.Request) {
 	// Check ticket
 	t, err := fetchTicketHeader(req)
 	if err != nil {
-		ErrorOut(w, http.StatusUnauthorized, invalidTicketID)
+		httputils.ErrorOut(w, http.StatusUnauthorized, invalidTicketID)
 		return
 	}
 
@@ -154,7 +155,7 @@ func CompleteIncoming(w http.ResponseWriter, req *http.Request) {
 	ticketRepo := container.Instance.GetTicketRepo()
 	ticketRepo.Remove(t.ID)
 
-	_ = JSONOut(w, http.StatusAccepted, StatusOk("message accepted"))
+	_ = httputils.JSONOut(w, http.StatusAccepted, httputils.StatusOk("message accepted"))
 }
 
 // DeleteIncoming is called whenever we want to completely remove a message by user request
@@ -162,18 +163,18 @@ func DeleteIncoming(w http.ResponseWriter, req *http.Request) {
 	// Check ticket
 	t, err := fetchTicketHeader(req)
 	if err != nil {
-		ErrorOut(w, http.StatusUnauthorized, invalidTicketID)
+		httputils.ErrorOut(w, http.StatusUnauthorized, invalidTicketID)
 		return
 	}
 
 	if !message.IncomingPathExists(t.ID, "") {
-		ErrorOut(w, http.StatusNotFound, "message not found")
+		httputils.ErrorOut(w, http.StatusNotFound, "message not found")
 		return
 	}
 
 	err = message.RemoveMessage(message.SectionIncoming, t.ID)
 	if err != nil {
-		ErrorOut(w, http.StatusInternalServerError, "error while deleting outgoing message")
+		httputils.ErrorOut(w, http.StatusInternalServerError, "error while deleting outgoing message")
 		return
 	}
 
@@ -181,7 +182,7 @@ func DeleteIncoming(w http.ResponseWriter, req *http.Request) {
 	ticketRepo := container.Instance.GetTicketRepo()
 	ticketRepo.Remove(t.ID)
 
-	_ = JSONOut(w, http.StatusOK, StatusOk("message removed"))
+	_ = httputils.JSONOut(w, http.StatusOK, httputils.StatusOk("message removed"))
 }
 
 func readHeaderFromBody(body io.ReadCloser) (*message.Header, error) {

--- a/cmd/bm-server/handler/incoming.go
+++ b/cmd/bm-server/handler/incoming.go
@@ -75,9 +75,7 @@ func IncomingMessageHeader(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(StatusOk("header saved"))
+	_ = JSONOut(w, http.StatusOK, StatusOk("saved message header"))
 }
 
 // IncomingMessageCatalog deals with uploading message catalogs
@@ -95,9 +93,7 @@ func IncomingMessageCatalog(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(StatusOk("saved catalog"))
+	_ = JSONOut(w, http.StatusOK, StatusOk("saved message catalog"))
 }
 
 // IncomingMessageBlock deals with uploading message blocks
@@ -118,9 +114,7 @@ func IncomingMessageBlock(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(StatusOk("saved message block"))
+	_ = JSONOut(w, http.StatusOK, StatusOk("saved message block"))
 }
 
 // IncomingMessageAttachment deals with uploading message attachments
@@ -141,9 +135,7 @@ func IncomingMessageAttachment(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(StatusOk("saved message attachment"))
+	_ = JSONOut(w, http.StatusOK, StatusOk("saved message attachment"))
 }
 
 // CompleteIncoming is called whenever everything from a message has been uploaded and can be actually send
@@ -162,9 +154,7 @@ func CompleteIncoming(w http.ResponseWriter, req *http.Request) {
 	ticketRepo := container.Instance.GetTicketRepo()
 	ticketRepo.Remove(t.ID)
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusAccepted)
-	_ = json.NewEncoder(w).Encode(StatusOk("message accepted"))
+	_ = JSONOut(w, http.StatusAccepted, StatusOk("message accepted"))
 }
 
 // DeleteIncoming is called whenever we want to completely remove a message by user request
@@ -191,9 +181,7 @@ func DeleteIncoming(w http.ResponseWriter, req *http.Request) {
 	ticketRepo := container.Instance.GetTicketRepo()
 	ticketRepo.Remove(t.ID)
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(StatusOk("message removed"))
+	_ = JSONOut(w, http.StatusOK, StatusOk("message removed"))
 }
 
 func readHeaderFromBody(body io.ReadCloser) (*message.Header, error) {

--- a/cmd/bm-server/handler/message.go
+++ b/cmd/bm-server/handler/message.go
@@ -61,7 +61,7 @@ func GetMessage(w http.ResponseWriter, req *http.Request) {
 		Catalog: catalog,
 	}
 
-	_ = JSONOut(w, output)
+	_ = JSONOut(w, http.StatusOK, output)
 }
 
 // GetMessageBlock will return a message block

--- a/cmd/bm-server/handler/message.go
+++ b/cmd/bm-server/handler/message.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/container"
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/httputils"
 	"github.com/bitmaelum/bitmaelum-suite/internal/api"
 	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
 	"github.com/gorilla/mux"
@@ -39,13 +40,13 @@ const (
 func GetMessage(w http.ResponseWriter, req *http.Request) {
 	haddr, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
 		return
 	}
 
 	box, err := strconv.Atoi(mux.Vars(req)["box"])
 	if err != nil {
-		ErrorOut(w, http.StatusBadRequest, incorrectBox)
+		httputils.ErrorOut(w, http.StatusBadRequest, incorrectBox)
 		return
 	}
 
@@ -61,20 +62,20 @@ func GetMessage(w http.ResponseWriter, req *http.Request) {
 		Catalog: catalog,
 	}
 
-	_ = JSONOut(w, http.StatusOK, output)
+	_ = httputils.JSONOut(w, http.StatusOK, output)
 }
 
 // GetMessageBlock will return a message block
 func GetMessageBlock(w http.ResponseWriter, req *http.Request) {
 	haddr, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
 		return
 	}
 
 	box, err := strconv.Atoi(mux.Vars(req)["box"])
 	if err != nil {
-		ErrorOut(w, http.StatusBadRequest, incorrectBox)
+		httputils.ErrorOut(w, http.StatusBadRequest, incorrectBox)
 		return
 	}
 
@@ -84,7 +85,7 @@ func GetMessageBlock(w http.ResponseWriter, req *http.Request) {
 	ar := container.Instance.GetAccountRepo()
 	block, err := ar.FetchMessageBlock(*haddr, box, messageID, blockID)
 	if err != nil {
-		ErrorOut(w, http.StatusBadRequest, incorrectBox)
+		httputils.ErrorOut(w, http.StatusBadRequest, incorrectBox)
 		return
 	}
 
@@ -97,13 +98,13 @@ func GetMessageBlock(w http.ResponseWriter, req *http.Request) {
 func GetMessageAttachment(w http.ResponseWriter, req *http.Request) {
 	haddr, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
 		return
 	}
 
 	box, err := strconv.Atoi(mux.Vars(req)["box"])
 	if err != nil {
-		ErrorOut(w, http.StatusBadRequest, incorrectBox)
+		httputils.ErrorOut(w, http.StatusBadRequest, incorrectBox)
 		return
 	}
 
@@ -113,7 +114,7 @@ func GetMessageAttachment(w http.ResponseWriter, req *http.Request) {
 	ar := container.Instance.GetAccountRepo()
 	attachment, size, err := ar.FetchMessageAttachment(*haddr, box, messageID, attachmentID)
 	if err != nil {
-		ErrorOut(w, http.StatusBadRequest, "incorrect attachment")
+		httputils.ErrorOut(w, http.StatusBadRequest, "incorrect attachment")
 		return
 	}
 

--- a/cmd/bm-server/handler/mgmt/api_key.go
+++ b/cmd/bm-server/handler/mgmt/api_key.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/handler"
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/httputils"
 	"github.com/bitmaelum/bitmaelum-suite/internal"
 	"github.com/bitmaelum/bitmaelum-suite/internal/container"
 	"github.com/bitmaelum/bitmaelum-suite/internal/key"
@@ -41,9 +42,9 @@ type inputAPIKeyType struct {
 // NewAPIKey is a handler that will create a new API key (non-admin keys only)
 func NewAPIKey(w http.ResponseWriter, req *http.Request) {
 	var input inputAPIKeyType
-	err := handler.DecodeBody(w, req.Body, &input)
+	err := httputils.DecodeBody(w, req.Body, &input)
 	if err != nil {
-		handler.ErrorOut(w, http.StatusBadRequest, "incorrect body")
+		httputils.ErrorOut(w, http.StatusBadRequest, "incorrect body")
 		return
 	}
 
@@ -54,19 +55,19 @@ func NewAPIKey(w http.ResponseWriter, req *http.Request) {
 		h = &tmp
 	}
 	if h == nil {
-		handler.ErrorOut(w, http.StatusBadRequest, "incorrect hash")
+		httputils.ErrorOut(w, http.StatusBadRequest, "incorrect hash")
 		return
 	}
 
 	k := handler.GetAPIKey(req)
 	if !k.HasPermission(internal.PermAPIKeys, h) {
-		handler.ErrorOut(w, http.StatusUnauthorized, "unauthorized")
+		httputils.ErrorOut(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 
 	err = internal.CheckManagementPermissions(input.Permissions)
 	if err != nil {
-		handler.ErrorOut(w, http.StatusBadRequest, "incorrect permissions")
+		httputils.ErrorOut(w, http.StatusBadRequest, "incorrect permissions")
 		return
 	}
 
@@ -77,12 +78,12 @@ func NewAPIKey(w http.ResponseWriter, req *http.Request) {
 	err = repo.Store(newAPIKey)
 	if err != nil {
 		msg := fmt.Sprintf("error while storing key: %s", err)
-		handler.ErrorOut(w, http.StatusInternalServerError, msg)
+		httputils.ErrorOut(w, http.StatusInternalServerError, msg)
 		return
 	}
 
 	// Output key
-	_ = handler.JSONOut(w, http.StatusCreated, jsonOut{
+	_ = httputils.JSONOut(w, http.StatusCreated, jsonOut{
 		"api_key": newAPIKey.ID,
 	})
 }

--- a/cmd/bm-server/handler/mgmt/api_key.go
+++ b/cmd/bm-server/handler/mgmt/api_key.go
@@ -28,6 +28,7 @@ import (
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/httputils"
 	"github.com/bitmaelum/bitmaelum-suite/internal"
 	"github.com/bitmaelum/bitmaelum-suite/internal/container"
+	"github.com/bitmaelum/bitmaelum-suite/internal/dispatcher"
 	"github.com/bitmaelum/bitmaelum-suite/internal/key"
 	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
 )
@@ -81,6 +82,8 @@ func NewAPIKey(w http.ResponseWriter, req *http.Request) {
 		httputils.ErrorOut(w, http.StatusInternalServerError, msg)
 		return
 	}
+
+	_ = dispatcher.DispatchApiKeyCreate(*h, newAPIKey)
 
 	// Output key
 	_ = httputils.JSONOut(w, http.StatusCreated, jsonOut{

--- a/cmd/bm-server/handler/mgmt/api_key.go
+++ b/cmd/bm-server/handler/mgmt/api_key.go
@@ -20,7 +20,6 @@
 package mgmt
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -83,9 +82,7 @@ func NewAPIKey(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Output key
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(jsonOut{
+	_ = handler.JSONOut(w, http.StatusCreated, jsonOut{
 		"api_key": newAPIKey.ID,
 	})
 }

--- a/cmd/bm-server/handler/mgmt/api_key.go
+++ b/cmd/bm-server/handler/mgmt/api_key.go
@@ -83,7 +83,7 @@ func NewAPIKey(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	_ = dispatcher.DispatchApiKeyCreate(*h, newAPIKey)
+	_ = dispatcher.DispatchAPIKeyCreate(*h, newAPIKey)
 
 	// Output key
 	_ = httputils.JSONOut(w, http.StatusCreated, jsonOut{

--- a/cmd/bm-server/handler/mgmt/flush.go
+++ b/cmd/bm-server/handler/mgmt/flush.go
@@ -20,7 +20,6 @@
 package mgmt
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/handler"
@@ -44,7 +43,5 @@ func FlushQueues(w http.ResponseWriter, req *http.Request) {
 	go processor.ProcessStuckIncomingMessages()
 	go processor.ProcessStuckProcessingMessages()
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(handler.StatusOk("Flushing queues"))
+	_ = handler.JSONOut(w, http.StatusOK, handler.StatusOk("Flushing queues"))
 }

--- a/cmd/bm-server/handler/mgmt/flush.go
+++ b/cmd/bm-server/handler/mgmt/flush.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/handler"
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/httputils"
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/processor"
 	"github.com/bitmaelum/bitmaelum-suite/internal"
 )
@@ -31,7 +32,7 @@ import (
 func FlushQueues(w http.ResponseWriter, req *http.Request) {
 	k := handler.GetAPIKey(req)
 	if !k.HasPermission(internal.PermFlush, nil) {
-		handler.ErrorOut(w, http.StatusUnauthorized, "unauthorized")
+		httputils.ErrorOut(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 
@@ -43,5 +44,5 @@ func FlushQueues(w http.ResponseWriter, req *http.Request) {
 	go processor.ProcessStuckIncomingMessages()
 	go processor.ProcessStuckProcessingMessages()
 
-	_ = handler.JSONOut(w, http.StatusOK, handler.StatusOk("Flushing queues"))
+	_ = httputils.JSONOut(w, http.StatusOK, httputils.StatusOk("Flushing queues"))
 }

--- a/cmd/bm-server/handler/mgmt/invite.go
+++ b/cmd/bm-server/handler/mgmt/invite.go
@@ -20,7 +20,6 @@
 package mgmt
 
 import (
-	"encoding/json"
 	"net/http"
 	"time"
 
@@ -66,9 +65,7 @@ func NewInvite(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(jsonOut{
+	_ = handler.JSONOut(w, http.StatusCreated, jsonOut{
 		"hash":   addrHash.String(),
 		"token":  token.String(),
 		"expiry": validUntil.Unix(),

--- a/cmd/bm-server/handler/mgmt/invite.go
+++ b/cmd/bm-server/handler/mgmt/invite.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/handler"
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/httputils"
 	"github.com/bitmaelum/bitmaelum-suite/internal"
 	"github.com/bitmaelum/bitmaelum-suite/internal/config"
 	"github.com/bitmaelum/bitmaelum-suite/internal/signature"
@@ -41,31 +42,31 @@ type jsonOut map[string]interface{}
 func NewInvite(w http.ResponseWriter, req *http.Request) {
 	k := handler.GetAPIKey(req)
 	if !k.HasPermission(internal.PermGenerateInvites, nil) {
-		handler.ErrorOut(w, http.StatusUnauthorized, "unauthorized")
+		httputils.ErrorOut(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 
 	var input inputInviteType
-	err := handler.DecodeBody(w, req.Body, &input)
+	err := httputils.DecodeBody(w, req.Body, &input)
 	if err != nil {
-		handler.ErrorOut(w, http.StatusBadRequest, "incorrect body")
+		httputils.ErrorOut(w, http.StatusBadRequest, "incorrect body")
 		return
 	}
 
 	addrHash, err := hash.NewFromHash(input.AddrHash)
 	if err != nil {
-		handler.ErrorOut(w, http.StatusBadRequest, "incorrect address")
+		httputils.ErrorOut(w, http.StatusBadRequest, "incorrect address")
 		return
 	}
 
 	validUntil := time.Now().Add(time.Duration(input.Days) * 24 * time.Hour)
 	token, err := signature.NewInviteToken(*addrHash, config.Routing.RoutingID, validUntil, config.Routing.PrivateKey)
 	if err != nil {
-		handler.ErrorOut(w, http.StatusInternalServerError, "cannot generate invite token")
+		httputils.ErrorOut(w, http.StatusInternalServerError, "cannot generate invite token")
 		return
 	}
 
-	_ = handler.JSONOut(w, http.StatusCreated, jsonOut{
+	_ = httputils.JSONOut(w, http.StatusCreated, jsonOut{
 		"hash":   addrHash.String(),
 		"token":  token.String(),
 		"expiry": validUntil.Unix(),

--- a/cmd/bm-server/handler/ticket.go
+++ b/cmd/bm-server/handler/ticket.go
@@ -95,9 +95,7 @@ func GetClientToServerTicket(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Send out our validated ticket
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(ticket.NewSimpleTicket(t))
+	_ = JSONOut(w, http.StatusOK, ticket.NewSimpleTicket(t))
 }
 
 // GetServerToServerTicket will try and retrieve a (valid) ticket so we can upload messages. It is only allowed to have a
@@ -188,15 +186,14 @@ func GetServerToServerTicket(w http.ResponseWriter, req *http.Request) {
 	outputTicket(tckt, w)
 }
 
+// Send out validated or invalidated ticket and status
 func outputTicket(tckt *ticket.Ticket, w http.ResponseWriter) {
-	// Send out validated or invalidated ticket and status
-	w.Header().Set("Content-Type", "application/json")
-	if tckt.Valid {
-		w.WriteHeader(http.StatusOK)
-	} else {
-		w.WriteHeader(http.StatusPreconditionFailed)
+	status := http.StatusOK
+	if !tckt.Valid {
+		status = http.StatusPreconditionFailed
 	}
-	_ = json.NewEncoder(w).Encode(ticket.NewSimpleTicket(tckt))
+
+	_ = JSONOut(w, status, ticket.NewSimpleTicket(tckt))
 }
 
 func handleSubscription(requestInfo *requestInfoType) (*ticket.Ticket, error) {

--- a/cmd/bm-server/handler/utils.go
+++ b/cmd/bm-server/handler/utils.go
@@ -20,81 +20,11 @@
 package handler
 
 import (
-	"encoding/json"
-	"io"
 	"net/http"
 
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/middleware/auth"
 	"github.com/bitmaelum/bitmaelum-suite/internal/key"
-	"github.com/sirupsen/logrus"
 )
-
-// OutputResponse is a generic output response
-type OutputResponse struct {
-	Error  bool   `json:"error,omitempty"`
-	Status string `json:"status"`
-}
-
-// JSONOut outputs the given data structure to JSON
-func JSONOut(w http.ResponseWriter, statusCode int, v interface{}) error {
-	var data []byte
-	var err error
-
-	// Indent or not, depends on the x-pretty-json header set in the response. This is set by the prettyjson middleware
-	if w.Header().Get("x-pretty-json") == "1" {
-		data, err = json.MarshalIndent(v, "", "  ")
-	} else {
-		data, err = json.Marshal(v)
-	}
-	w.Header().Del("x-pretty-json")
-
-	if err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		_ = json.NewEncoder(w).Encode(StatusError("Malformed JSON: " + err.Error()))
-		return err
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
-	_, err = w.Write(data)
-	return err
-}
-
-// ErrorOut outputs an error
-func ErrorOut(w http.ResponseWriter, code int, msg string) {
-	logrus.Debugf("Returning error (%d): %s", code, msg)
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(code)
-	_ = json.NewEncoder(w).Encode(StatusError(msg))
-}
-
-// StatusOk Return an ok status response
-func StatusOk(status string) *OutputResponse {
-	return &OutputResponse{
-		Status: status,
-	}
-}
-
-// StatusError Return an error status response
-func StatusError(status string) *OutputResponse {
-	return &OutputResponse{
-		Error:  true,
-		Status: status,
-	}
-}
-
-// DecodeBody decodes a JSON body or write/return an error if an error occurs
-func DecodeBody(w http.ResponseWriter, body io.ReadCloser, v interface{}) error {
-	decoder := json.NewDecoder(body)
-	err := decoder.Decode(v)
-	if err != nil {
-		_ = JSONOut(w, http.StatusBadRequest, StatusError("Malformed JSON: " + err.Error()))
-		return err
-	}
-
-	return nil
-}
 
 // GetAPIKey returns the api key stored in the request context. If not found, it will return a dummy key with no permissions
 func GetAPIKey(req *http.Request) *key.APIKeyType {

--- a/cmd/bm-server/handler/utils.go
+++ b/cmd/bm-server/handler/utils.go
@@ -36,7 +36,7 @@ type OutputResponse struct {
 }
 
 // JSONOut outputs the given data structure to JSON
-func JSONOut(w http.ResponseWriter, v interface{}) error {
+func JSONOut(w http.ResponseWriter, statusCode int, v interface{}) error {
 	var data []byte
 	var err error
 
@@ -56,7 +56,7 @@ func JSONOut(w http.ResponseWriter, v interface{}) error {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(statusCode)
 	_, err = w.Write(data)
 	return err
 }
@@ -89,9 +89,7 @@ func DecodeBody(w http.ResponseWriter, body io.ReadCloser, v interface{}) error 
 	decoder := json.NewDecoder(body)
 	err := decoder.Decode(v)
 	if err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		_ = json.NewEncoder(w).Encode(StatusError("Malformed JSON: " + err.Error()))
+		_ = JSONOut(w, http.StatusBadRequest, StatusError("Malformed JSON: " + err.Error()))
 		return err
 	}
 

--- a/cmd/bm-server/handler/webhooks.go
+++ b/cmd/bm-server/handler/webhooks.go
@@ -21,6 +21,7 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -75,11 +76,7 @@ func CreateWebhook(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Output webhook
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(jsonOut{
-		"webhook_id": wh.ID,
-	})
+	_ = JSONOut(w, http.StatusCreated, wh)
 }
 
 // ListWebhooks returns a list of all webhooks for the given account
@@ -99,9 +96,7 @@ func ListWebhooks(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Output wh
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(webhooks)
+	_ = JSONOut(w, http.StatusOK, webhooks)
 }
 
 // DeleteWebhook will remove a webhook
@@ -119,15 +114,14 @@ func DeleteWebhook(w http.ResponseWriter, req *http.Request) {
 	wh, err := repo.Fetch(whID)
 	if err != nil || wh.Account.String() != h.String() {
 		// Only allow deleting of webhooks that we own as account
-		ErrorOut(w, http.StatusNotFound, "webhook not found")
+		ErrorOut(w, http.StatusNotFound, errWebhookNotFound.Error())
 		return
 	}
 
 	_ = repo.Remove(*wh)
 
 	// All is well
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	_ = JSONOut(w, http.StatusNoContent, nil)
 }
 
 // GetWebhookDetails will get a webhook
@@ -144,14 +138,12 @@ func GetWebhookDetails(w http.ResponseWriter, req *http.Request) {
 	repo := container.Instance.GetWebhookRepo()
 	wh, err := repo.Fetch(whID)
 	if err != nil || wh.Account.String() != h.String() {
-		ErrorOut(w, http.StatusNotFound, "webhook not found")
+		ErrorOut(w, http.StatusNotFound, errWebhookNotFound.Error())
 		return
 	}
 
 	// Output webhook
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(wh)
+	_ = JSONOut(w, http.StatusOK, wh)
 }
 
 // EnableWebhook will enable a webhook
@@ -191,6 +183,5 @@ func endis(w http.ResponseWriter, req *http.Request, status bool) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	_ = JSONOut(w, http.StatusOK, jsonOut{})
 }

--- a/cmd/bm-server/handler/webhooks.go
+++ b/cmd/bm-server/handler/webhooks.go
@@ -31,6 +31,11 @@ import (
 	"github.com/gorilla/mux"
 )
 
+var (
+	errIncorrectBody = errors.New("incorrect body")
+	errWebhookNotFound = errors.New("webhook not found")
+)
+
 type inputWebhookType struct {
 	Event  webhook.EventEnum `json:"event"`
 	Type   webhook.TypeEnum  `json:"type"`
@@ -42,7 +47,7 @@ func CreateWebhook(w http.ResponseWriter, req *http.Request) {
 	var input inputWebhookType
 	err := DecodeBody(w, req.Body, &input)
 	if err != nil {
-		ErrorOut(w, http.StatusBadRequest, "incorrect body")
+		ErrorOut(w, http.StatusBadRequest, errIncorrectBody.Error())
 		return
 	}
 
@@ -56,13 +61,13 @@ func CreateWebhook(w http.ResponseWriter, req *http.Request) {
 
 	cfg, err := json.Marshal(input.Config)
 	if err != nil {
-		ErrorOut(w, http.StatusBadRequest, "incorrect body")
+		ErrorOut(w, http.StatusBadRequest, errIncorrectBody.Error())
 		return
 	}
 
 	wh, err := webhook.NewWebhook(*h, input.Event, input.Type, cfg)
 	if err != nil {
-		ErrorOut(w, http.StatusBadRequest, "incorrect body")
+		ErrorOut(w, http.StatusBadRequest, errIncorrectBody.Error())
 		return
 	}
 
@@ -169,7 +174,7 @@ func endis(w http.ResponseWriter, req *http.Request, status bool) {
 	repo := container.Instance.GetWebhookRepo()
 	wh, err := repo.Fetch(whID)
 	if err != nil || wh.Account.String() != h.String() {
-		ErrorOut(w, http.StatusNotFound, "webhook not found")
+		ErrorOut(w, http.StatusNotFound, errWebhookNotFound.Error())
 		return
 	}
 

--- a/cmd/bm-server/handler/webhooks.go
+++ b/cmd/bm-server/handler/webhooks.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/httputils"
 	"github.com/bitmaelum/bitmaelum-suite/internal/container"
+	"github.com/bitmaelum/bitmaelum-suite/internal/dispatcher"
 	"github.com/bitmaelum/bitmaelum-suite/internal/webhook"
 	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
 	"github.com/gorilla/mux"
@@ -89,6 +90,8 @@ func CreateWebhook(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	_ = dispatcher.DispatchWebhookCreate(wh.Account, *wh)
+
 	// Output webhook
 	_ = httputils.JSONOut(w, http.StatusCreated, wh)
 }
@@ -118,6 +121,8 @@ func UpdateWebhook(w http.ResponseWriter, req *http.Request) {
 		httputils.ErrorOut(w, http.StatusInternalServerError, msg)
 		return
 	}
+
+	_ = dispatcher.DispatchWebhookUpdate(wh.Account, *wh)
 
 	// Output webhook
 	_ = httputils.JSONOut(w, http.StatusCreated, wh)
@@ -152,6 +157,8 @@ func DeleteWebhook(w http.ResponseWriter, req *http.Request) {
 
 	repo := container.Instance.GetWebhookRepo()
 	_ = repo.Remove(*wh)
+
+	_ = dispatcher.DispatchWebhookDelete(wh.Account, *wh)
 
 	// All is well
 	_ = httputils.JSONOut(w, http.StatusNoContent, nil)

--- a/cmd/bm-server/handler/webhooks.go
+++ b/cmd/bm-server/handler/webhooks.go
@@ -198,9 +198,11 @@ func endis(w http.ResponseWriter, req *http.Request, status bool) {
 	repo := container.Instance.GetWebhookRepo()
 	err = repo.Store(*wh)
 	if err != nil {
-		httputils.ErrorOut(w, http.StatusInternalServerError, "cannot enable")
+		httputils.ErrorOut(w, http.StatusInternalServerError, "cannot en/disable")
 		return
 	}
+
+	_ = dispatcher.DispatchWebhookUpdate(wh.Account, *wh)
 
 	_ = httputils.JSONOut(w, http.StatusOK, jsonOut{})
 }

--- a/cmd/bm-server/handler/webhooks.go
+++ b/cmd/bm-server/handler/webhooks.go
@@ -33,8 +33,9 @@ import (
 )
 
 var (
-	errIncorrectBody = errors.New("incorrect body")
+	errIncorrectBody   = errors.New("incorrect body")
 	errWebhookNotFound = errors.New("webhook not found")
+	errAccountNotFound = errors.New("account not found")
 )
 
 type inputWebhookType struct {
@@ -107,23 +108,12 @@ func ListWebhooks(w http.ResponseWriter, req *http.Request) {
 
 // DeleteWebhook will remove a webhook
 func DeleteWebhook(w http.ResponseWriter, req *http.Request) {
-	h, err := hash.NewFromHash(mux.Vars(req)["addr"])
+	wh, err := hasWebhookAccess(w, req)
 	if err != nil {
-		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
 		return
 	}
 
-	whID := mux.Vars(req)["id"]
-
-	// Fetch webhook
 	repo := container.Instance.GetWebhookRepo()
-	wh, err := repo.Fetch(whID)
-	if err != nil || wh.Account.String() != h.String() {
-		// Only allow deleting of webhooks that we own as account
-		httputils.ErrorOut(w, http.StatusNotFound, errWebhookNotFound.Error())
-		return
-	}
-
 	_ = repo.Remove(*wh)
 
 	// All is well
@@ -132,19 +122,8 @@ func DeleteWebhook(w http.ResponseWriter, req *http.Request) {
 
 // GetWebhookDetails will get a webhook
 func GetWebhookDetails(w http.ResponseWriter, req *http.Request) {
-	h, err := hash.NewFromHash(mux.Vars(req)["addr"])
+	wh, err := hasWebhookAccess(w, req)
 	if err != nil {
-		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
-		return
-	}
-
-	whID := mux.Vars(req)["id"]
-
-	// Fetch webhook
-	repo := container.Instance.GetWebhookRepo()
-	wh, err := repo.Fetch(whID)
-	if err != nil || wh.Account.String() != h.String() {
-		httputils.ErrorOut(w, http.StatusNotFound, errWebhookNotFound.Error())
 		return
 	}
 
@@ -163,10 +142,30 @@ func DisableWebhook(w http.ResponseWriter, req *http.Request) {
 }
 
 func endis(w http.ResponseWriter, req *http.Request, status bool) {
+	wh, err := hasWebhookAccess(w, req)
+	if err != nil {
+		return
+	}
+
+	// set wh status
+	wh.Enabled = status
+
+	// Store
+	repo := container.Instance.GetWebhookRepo()
+	err = repo.Store(*wh)
+	if err != nil {
+		httputils.ErrorOut(w, http.StatusInternalServerError, "cannot enable")
+		return
+	}
+
+	_ = httputils.JSONOut(w, http.StatusOK, jsonOut{})
+}
+
+func hasWebhookAccess(w http.ResponseWriter, req *http.Request) (*webhook.Type, error) {
 	h, err := hash.NewFromHash(mux.Vars(req)["addr"])
 	if err != nil {
-		httputils.ErrorOut(w, http.StatusNotFound, accountNotFound)
-		return
+		httputils.ErrorOut(w, http.StatusNotFound, errAccountNotFound.Error())
+		return nil, errAccountNotFound
 	}
 
 	whID := mux.Vars(req)["id"]
@@ -175,19 +174,10 @@ func endis(w http.ResponseWriter, req *http.Request, status bool) {
 	repo := container.Instance.GetWebhookRepo()
 	wh, err := repo.Fetch(whID)
 	if err != nil || wh.Account.String() != h.String() {
+		// Only allow deleting of webhooks that we own as account
 		httputils.ErrorOut(w, http.StatusNotFound, errWebhookNotFound.Error())
-		return
+		return nil, errWebhookNotFound
 	}
 
-	// set wh status
-	wh.Enabled = status
-
-	// Store
-	err = repo.Store(*wh)
-	if err != nil {
-		httputils.ErrorOut(w, http.StatusInternalServerError, "cannot enable")
-		return
-	}
-
-	_ = httputils.JSONOut(w, http.StatusOK, jsonOut{})
+	return wh, nil
 }

--- a/cmd/bm-server/handler/webhooks.go
+++ b/cmd/bm-server/handler/webhooks.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/bitmaelum/bitmaelum-suite/internal/container"
+	"github.com/bitmaelum/bitmaelum-suite/internal/webhook"
+	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
+	"github.com/gorilla/mux"
+)
+
+type inputWebhookType struct {
+	Event  webhook.EventEnum `json:"event"`
+	Type   webhook.TypeEnum  `json:"type"`
+	Config map[string]string `json:"config"`
+}
+
+// CreateWebhook is a handler that will create a new webhook
+func CreateWebhook(w http.ResponseWriter, req *http.Request) {
+	var input inputWebhookType
+	err := DecodeBody(w, req.Body, &input)
+	if err != nil {
+		ErrorOut(w, http.StatusBadRequest, "incorrect body")
+		return
+	}
+
+	// @TODO check webhook input, and configs
+
+	h, err := hash.NewFromHash(mux.Vars(req)["addr"])
+	if err != nil {
+		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		return
+	}
+
+	cfg, err := json.Marshal(input.Config)
+	if err != nil {
+		ErrorOut(w, http.StatusBadRequest, "incorrect body")
+		return
+	}
+
+	wh, err := webhook.NewWebhook(*h, input.Event, input.Type, cfg)
+	if err != nil {
+		ErrorOut(w, http.StatusBadRequest, "incorrect body")
+		return
+	}
+
+	// Store webhook into persistent storage
+	repo := container.Instance.GetWebhookRepo()
+	err = repo.Store(*wh)
+	if err != nil {
+		msg := fmt.Sprintf("error while storing webhook: %s", err)
+		ErrorOut(w, http.StatusInternalServerError, msg)
+		return
+	}
+
+	// Output webhook
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(jsonOut{
+		"webhook_id": wh.ID,
+	})
+}
+
+// ListWebhooks returns a list of all webhooks for the given account
+func ListWebhooks(w http.ResponseWriter, req *http.Request) {
+	h, err := hash.NewFromHash(mux.Vars(req)["addr"])
+	if err != nil {
+		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		return
+	}
+
+	repo := container.Instance.GetWebhookRepo()
+	webhooks, err := repo.FetchByHash(*h)
+	if err != nil {
+		msg := fmt.Sprintf("error while retrieving webhooks: %s", err)
+		ErrorOut(w, http.StatusInternalServerError, msg)
+		return
+	}
+
+	// Output wh
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(webhooks)
+}
+
+// DeleteWebhook will remove a webhook
+func DeleteWebhook(w http.ResponseWriter, req *http.Request) {
+	h, err := hash.NewFromHash(mux.Vars(req)["addr"])
+	if err != nil {
+		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		return
+	}
+
+	whID := mux.Vars(req)["id"]
+
+	// Fetch webhook
+	repo := container.Instance.GetWebhookRepo()
+	wh, err := repo.Fetch(whID)
+	if err != nil || wh.Account.String() != h.String() {
+		// Only allow deleting of webhooks that we own as account
+		ErrorOut(w, http.StatusNotFound, "webhook not found")
+		return
+	}
+
+	_ = repo.Remove(*wh)
+
+	// All is well
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+}
+
+// GetWebhookDetails will get a webhook
+func GetWebhookDetails(w http.ResponseWriter, req *http.Request) {
+	h, err := hash.NewFromHash(mux.Vars(req)["addr"])
+	if err != nil {
+		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		return
+	}
+
+	whID := mux.Vars(req)["id"]
+
+	// Fetch webhook
+	repo := container.Instance.GetWebhookRepo()
+	wh, err := repo.Fetch(whID)
+	if err != nil || wh.Account.String() != h.String() {
+		ErrorOut(w, http.StatusNotFound, "webhook not found")
+		return
+	}
+
+	// Output webhook
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(wh)
+}
+
+// EnableWebhook will enable a webhook
+func EnableWebhook(w http.ResponseWriter, req *http.Request) {
+	endis(w, req, true)
+}
+
+// DisableWebhook will enable a webhook
+func DisableWebhook(w http.ResponseWriter, req *http.Request) {
+	endis(w, req, false)
+}
+
+func endis(w http.ResponseWriter, req *http.Request, status bool) {
+	h, err := hash.NewFromHash(mux.Vars(req)["addr"])
+	if err != nil {
+		ErrorOut(w, http.StatusNotFound, accountNotFound)
+		return
+	}
+
+	whID := mux.Vars(req)["id"]
+
+	// Fetch webhook
+	repo := container.Instance.GetWebhookRepo()
+	wh, err := repo.Fetch(whID)
+	if err != nil || wh.Account.String() != h.String() {
+		ErrorOut(w, http.StatusNotFound, "webhook not found")
+		return
+	}
+
+	// set wh status
+	wh.Enabled = status
+
+	// Store
+	err = repo.Store(*wh)
+	if err != nil {
+		ErrorOut(w, http.StatusInternalServerError, "cannot enable")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+}

--- a/cmd/bm-server/internal/container/container.go
+++ b/cmd/bm-server/internal/container/container.go
@@ -26,6 +26,7 @@ import (
 	"github.com/bitmaelum/bitmaelum-suite/internal/resolver"
 	"github.com/bitmaelum/bitmaelum-suite/internal/subscription"
 	"github.com/bitmaelum/bitmaelum-suite/internal/ticket"
+	"github.com/bitmaelum/bitmaelum-suite/internal/webhook"
 )
 
 /*
@@ -114,4 +115,13 @@ func (c *MultiContainer) GetTicketRepo() ticket.Repository {
 	}
 
 	return c.general.Get("ticket").(ticket.Repository)
+}
+
+// GetWebhookRepo will return the current web hook repository
+func (c *MultiContainer) GetWebhookRepo() webhook.Repository {
+	if c.client.Has("webhook") {
+		return c.client.Get("webhook").(webhook.Repository)
+	}
+
+	return c.general.Get("webhook").(webhook.Repository)
 }

--- a/cmd/bm-server/internal/httputils/http.go
+++ b/cmd/bm-server/internal/httputils/http.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package httputils
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+)
+
+// OutputResponse is a generic output response
+type OutputResponse struct {
+	Error  bool   `json:"error,omitempty"`
+	Status string `json:"status"`
+}
+
+// JSONOut outputs the given data structure to JSON
+func JSONOut(w http.ResponseWriter, statusCode int, v interface{}) error {
+	var data []byte
+	var err error
+
+	// Indent or not, depends on the x-pretty-json header set in the response. This is set by the prettyjson middleware
+	if w.Header().Get("x-pretty-json") == "1" {
+		data, err = json.MarshalIndent(v, "", "  ")
+	} else {
+		data, err = json.Marshal(v)
+	}
+	w.Header().Del("x-pretty-json")
+
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(StatusError("Malformed JSON: " + err.Error()))
+		return err
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_, err = w.Write(data)
+	return err
+}
+
+// ErrorOut outputs an error
+func ErrorOut(w http.ResponseWriter, code int, msg string) {
+	logrus.Debugf("Returning error (%d): %s", code, msg)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(StatusError(msg))
+}
+
+// StatusOk Return an ok status response
+func StatusOk(status string) *OutputResponse {
+	return &OutputResponse{
+		Status: status,
+	}
+}
+
+// StatusError Return an error status response
+func StatusError(status string) *OutputResponse {
+	return &OutputResponse{
+		Error:  true,
+		Status: status,
+	}
+}
+
+// DecodeBody decodes a JSON body or write/return an error if an error occurs
+func DecodeBody(w http.ResponseWriter, body io.ReadCloser, v interface{}) error {
+	decoder := json.NewDecoder(body)
+	err := decoder.Decode(v)
+	if err != nil {
+		_ = JSONOut(w, http.StatusBadRequest, StatusError("Malformed JSON: " + err.Error()))
+		return err
+	}
+
+	return nil
+}

--- a/cmd/bm-server/internal/httputils/http.go
+++ b/cmd/bm-server/internal/httputils/http.go
@@ -87,7 +87,7 @@ func DecodeBody(w http.ResponseWriter, body io.ReadCloser, v interface{}) error 
 	decoder := json.NewDecoder(body)
 	err := decoder.Decode(v)
 	if err != nil {
-		_ = JSONOut(w, http.StatusBadRequest, StatusError("Malformed JSON: " + err.Error()))
+		_ = JSONOut(w, http.StatusBadRequest, StatusError("Malformed JSON: "+err.Error()))
 		return err
 	}
 

--- a/cmd/bm-server/main.go
+++ b/cmd/bm-server/main.go
@@ -232,6 +232,7 @@ func setupRouter() *mux.Router {
 		authRouter.HandleFunc("/account/{addr:[A-Za-z0-9]{64}}/webhook/{id}/enable", handler.EnableWebhook).Methods("POST")
 		authRouter.HandleFunc("/account/{addr:[A-Za-z0-9]{64}}/webhook/{id}/disable", handler.DisableWebhook).Methods("POST")
 		authRouter.HandleFunc("/account/{addr:[A-Za-z0-9]{64}}/webhook/{id}", handler.GetWebhookDetails).Methods("GET")
+		authRouter.HandleFunc("/account/{addr:[A-Za-z0-9]{64}}/webhook/{id}", handler.UpdateWebhook).Methods("POST")
 		authRouter.HandleFunc("/account/{addr:[A-Za-z0-9]{64}}/webhook/{id}", handler.DeleteWebhook).Methods("DELETE")
 	}
 

--- a/cmd/bm-server/main.go
+++ b/cmd/bm-server/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/processor"
 	"github.com/bitmaelum/bitmaelum-suite/internal"
 	"github.com/bitmaelum/bitmaelum-suite/internal/config"
+	"github.com/bitmaelum/bitmaelum-suite/internal/dispatcher"
 	"github.com/bitmaelum/bitmaelum-suite/internal/message"
 	"github.com/bitmaelum/bitmaelum-suite/internal/resolver"
 	"github.com/gorilla/handlers"
@@ -81,6 +82,11 @@ func main() {
 	logrus.Tracef("Starting main loop")
 	go mainLoop(ctx)
 
+	// Start webhook dispatcher if enabled
+	if config.Server.Webhooks.Enabled {
+		initDispatcher()
+	}
+
 	// Start HTTP server
 	host := fmt.Sprintf("%s:%d", config.Server.Server.Host, config.Server.Server.Port)
 	logrus.Tracef("Starting BitMaelum HTTP service on '%s'", host)
@@ -90,6 +96,14 @@ func main() {
 	logrus.Tracef("Waiting until context tells us it's done")
 	<-ctx.Done()
 	logrus.Tracef("Context is done. Exiting")
+}
+
+func initDispatcher() {
+	logrus.Tracef("Starting webhooks")
+	if config.Server.Webhooks.System == "default" {
+		logrus.Tracef("Starting default dispatcher system")
+		dispatcher.InitDispatcher(config.Server.Webhooks.Workers)
+	}
 }
 
 func checkAndUpdateRouting() {
@@ -210,6 +224,16 @@ func setupRouter() *mux.Router {
 	authRouter.HandleFunc("/account/{addr:[A-Za-z0-9]{64}}/authkey", handler.ListAuthKeys).Methods("GET")
 	authRouter.HandleFunc("/account/{addr:[A-Za-z0-9]{64}}/authkey/{key}", handler.GetAuthKeyDetails).Methods("GET")
 	authRouter.HandleFunc("/account/{addr:[A-Za-z0-9]{64}}/authkey/{key}", handler.DeleteAuthKey).Methods("DELETE")
+
+	// Add webhooks if enabled
+	if config.Server.Webhooks.Enabled {
+		authRouter.HandleFunc("/account/{addr:[A-Za-z0-9]{64}}/webhook", handler.CreateWebhook).Methods("POST")
+		authRouter.HandleFunc("/account/{addr:[A-Za-z0-9]{64}}/webhook", handler.ListWebhooks).Methods("GET")
+		authRouter.HandleFunc("/account/{addr:[A-Za-z0-9]{64}}/webhook/{id}/enable", handler.EnableWebhook).Methods("POST")
+		authRouter.HandleFunc("/account/{addr:[A-Za-z0-9]{64}}/webhook/{id}/disable", handler.DisableWebhook).Methods("POST")
+		authRouter.HandleFunc("/account/{addr:[A-Za-z0-9]{64}}/webhook/{id}", handler.GetWebhookDetails).Methods("GET")
+		authRouter.HandleFunc("/account/{addr:[A-Za-z0-9]{64}}/webhook/{id}", handler.DeleteWebhook).Methods("DELETE")
+	}
 
 	//
 	// Routes that need to be authenticated through JWT or API keys

--- a/cmd/bm-server/middleware/authenticate.go
+++ b/cmd/bm-server/middleware/authenticate.go
@@ -21,10 +21,10 @@ package middleware
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/handler"
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 )

--- a/cmd/bm-server/middleware/authenticate.go
+++ b/cmd/bm-server/middleware/authenticate.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/handler"
+	"github.com/bitmaelum/bitmaelum-suite/cmd/bm-server/internal/httputils"
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 )
@@ -107,7 +107,7 @@ func ErrorOut(w http.ResponseWriter, code int, msg string) {
 
 	logrus.Debugf("Returning error (%d): %s", code, msg)
 
-	_ = handler.JSONOut(w, code, &OutputResponse{
+	_ = httputils.JSONOut(w, code, &OutputResponse{
 		Error:  true,
 		Status: msg,
 	})

--- a/cmd/bm-server/middleware/authenticate.go
+++ b/cmd/bm-server/middleware/authenticate.go
@@ -106,9 +106,8 @@ func ErrorOut(w http.ResponseWriter, code int, msg string) {
 	}
 
 	logrus.Debugf("Returning error (%d): %s", code, msg)
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(code)
-	_ = json.NewEncoder(w).Encode(&OutputResponse{
+
+	_ = handler.JSONOut(w, code, &OutputResponse{
 		Error:  true,
 		Status: msg,
 	})

--- a/cmd/bm-server/processor/process.go
+++ b/cmd/bm-server/processor/process.go
@@ -131,15 +131,14 @@ func deliverLocal(addrInfo *resolver.AddressInfo, msgID string, header *message.
 		return nil
 	}
 
-
 	// notify any webhooks
 	payload, err := json.Marshal(map[string]string{
 		"from": header.From.Addr.String(),
-		"to": header.To.Addr.String(),
-		"id": msgID,
+		"to":   header.To.Addr.String(),
+		"id":   msgID,
 	})
 	if err == nil {
-		_ = dispatcher.Dispatch(header.To.Addr, webhook.EventNewMessage, payload)
+		_ = dispatcher.Dispatch(header.To.Addr, webhook.EventLocalDelivery, payload)
 	}
 
 	return nil
@@ -234,11 +233,11 @@ func deliverRemote(addrInfo *resolver.AddressInfo, msgID string, header *message
 	// notify any webhooks
 	payload, err := json.Marshal(map[string]string{
 		"from": header.From.Addr.String(),
-		"to": header.To.Addr.String(),
-		"id": msgID,
+		"to":   header.To.Addr.String(),
+		"id":   msgID,
 	})
 	if err == nil {
-		_ = dispatcher.Dispatch(hash.New(addrInfo.Hash), webhook.EventOutgoingMessage, payload)
+		_ = dispatcher.Dispatch(hash.New(addrInfo.Hash), webhook.EventRemoveDelivery, payload)
 	}
 
 	// Remove local message from processing queue

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/mattn/go-sqlite3 v1.14.1
+	github.com/mborders/artifex v0.4.0
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nightlyone/lockfile v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-sqlite3 v1.14.1 h1:AHx9Ra40wIzl+GelgX2X6AWxmT5tfxhI1PL0523HcSw=
 github.com/mattn/go-sqlite3 v1.14.1/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mborders/artifex v0.4.0 h1:hhdWwq23dVzQe/2r9aeHdE2SdJKCWmXqBIQDP0NOqg8=
+github.com/mborders/artifex v0.4.0/go.mod h1:rk5wOc/2R6GlcqO1NzD1zpxC7RzIQnbjmOM23rOLfeo=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -184,6 +186,8 @@ github.com/rivo/tview v0.0.0-20200915114512-42866ecf6ca6 h1:LhmHZTzElCYlOXEWXWOQ
 github.com/rivo/tview v0.0.0-20200915114512-42866ecf6ca6/go.mod h1:xV4Aw4WIX8cmhg71U7MUHBdpIQ7zSEXdRruGHLaEAOc=
 github.com/rivo/uniseg v0.1.0 h1:+2KBaVoUmb9XzDsrx/Ct0W/EYOSFf/nWTauy++DprtY=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -287,8 +287,12 @@ func GetErrorFromResponse(body []byte) error {
 	}
 
 	s := &errorStatus{}
-	err := json.Unmarshal(body, &s)
-	if err != nil {
+	err := json.Unmarshal(body, s)
+	if err != nil || !s.Error {
+		return nil
+	}
+
+	if s.Status == "" && s.Error {
 		return errNoSuccess
 	}
 
@@ -302,7 +306,7 @@ func isErrorResponse(body []byte) bool {
 	}
 
 	s := &errorStatus{}
-	err := json.Unmarshal(body, &s)
+	err := json.Unmarshal(body, s)
 	if err != nil {
 		return false
 	}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientErrorResponses(t *testing.T) {
+	assert.False(t, isErrorResponse([]byte("")))
+	assert.False(t, isErrorResponse([]byte("null")))
+	assert.False(t, isErrorResponse([]byte("foobar")))
+	assert.False(t, isErrorResponse([]byte("{}")))
+	assert.False(t, isErrorResponse([]byte("{{{")))
+	assert.False(t, isErrorResponse([]byte("{\"error\": \"something\"}")))
+	assert.False(t, isErrorResponse([]byte("{\"status\": \"something\"}")))
+	assert.False(t, isErrorResponse([]byte("{\"error\": false, \"status\": \"error message\"}")))
+	assert.False(t, isErrorResponse([]byte("{\"error\": false, \"status\": \"\"}")))
+	assert.True(t, isErrorResponse([]byte("{\"error\": true, \"status\": \"error message\"}")))
+	assert.True(t, isErrorResponse([]byte("{\"error\": true}")))
+
+	assert.NoError(t, GetErrorFromResponse([]byte("")))
+	assert.NoError(t, GetErrorFromResponse([]byte("null")))
+	assert.NoError(t, GetErrorFromResponse([]byte("foobar")))
+	assert.NoError(t, GetErrorFromResponse([]byte("{}")))
+	assert.NoError(t, GetErrorFromResponse([]byte("{{{")))
+	assert.NoError(t, GetErrorFromResponse([]byte("{\"error\": \"something\"}")))
+	assert.NoError(t, GetErrorFromResponse([]byte("{\"status\": \"something\"}")))
+	assert.NoError(t, GetErrorFromResponse([]byte("{\"error\": false, \"status\": \"error message\"}")))
+	assert.NoError(t, GetErrorFromResponse([]byte("{\"error\": false, \"status\": \"\"}")))
+	assert.Errorf(t, GetErrorFromResponse([]byte("{\"error\": true}")), "unnown erorr")
+	assert.Errorf(t, GetErrorFromResponse([]byte("{\"error\": true, \"status\": \"error message\"}")), "error message")
+}
+
+func TestCanonicalHost(t *testing.T) {
+	assert.Equal(t, "https://foo.example.org:2424", CanonicalHost("foo.example.org"))
+	assert.Equal(t, "https://foo.example.org:80", CanonicalHost("foo.example.org:80"))
+	assert.Equal(t, "http://foo.example.org:2424", CanonicalHost("http://foo.example.org"))
+	assert.Equal(t, "mail://foo.example.org:2424", CanonicalHost("mail://foo.example.org"))
+	assert.Equal(t, "mail://foo.example.org:1234", CanonicalHost("mail://foo.example.org:1234"))
+	assert.Equal(t, "mail://192.168.1.1:1234", CanonicalHost("mail://192.168.1.1:1234"))
+	assert.Equal(t, "https://192.168.1.1:1234", CanonicalHost("192.168.1.1:1234"))
+	assert.Equal(t, "https://192.168.1.1:2424", CanonicalHost("192.168.1.1"))
+	assert.Equal(t, "https://[::1]:80", CanonicalHost("[::1]:80"))
+	assert.Equal(t, "https://[::1]:2424", CanonicalHost("[::1]"))
+	assert.Equal(t, "http://[::1]:2424", CanonicalHost("http://[::1]"))
+	assert.Equal(t, "http://[2a04:c44:e00:147a:441:aaff:fe00:1d2]:8080", CanonicalHost("http://[2a04:c44:e00:147a:441:aaff:fe00:1d2]:8080"))
+	assert.Equal(t, "https://[2a04:c44:e00:147a:441:aaff:fe00:1d2]:8080", CanonicalHost("https://[2a04:c44:e00:147a:441:aaff:fe00:1d2]:8080"))
+	assert.Equal(t, "https://[2a04:c44:e00:147a:441:aaff:fe00:1d2]:2424", CanonicalHost("[2a04:c44:e00:147a:441:aaff:fe00:1d2]"))
+}
+
+// // GetErrorFromResponse will return an error generated from the body
+// func GetErrorFromResponse(body []byte) error {
+// 	type errorStatus struct {
+// 		Error  bool   `json:"error"`
+// 		Status string `json:"status"`
+// 	}
+//
+// 	s := &errorStatus{Error: true}
+// 	err := json.Unmarshal(body, s)
+// 	if err != nil {
+// 		return errNoSuccess
+// 	}
+//
+// 	return errors.New(s.Status)
+// }

--- a/internal/api/webhook.go
+++ b/internal/api/webhook.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/bitmaelum/bitmaelum-suite/internal/webhook"
+	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
+)
+
+// CreateWebhook Create a new API key
+func (api *API) CreateWebhook(wh webhook.Type) error {
+	// ID is set by the server
+	wh.ID = ""
+	data, err := json.Marshal(wh)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("/account/%s/webhook", wh.Account.String())
+	body, statusCode, err := api.Post(url, data)
+	if err != nil {
+		return err
+	}
+
+	if statusCode < 200 || statusCode > 299 {
+		return errNoSuccess
+	}
+
+	if isErrorResponse(body) {
+		return GetErrorFromResponse(body)
+	}
+
+	return nil
+}
+
+// DeleteWebhook deletes a webhook
+func (api *API) DeleteWebhook(addrHash hash.Hash, ID string) error {
+	url := fmt.Sprintf("/account/%s/webhook/%s", addrHash.String(), ID)
+	body, statusCode, err := api.Delete(url)
+	if err != nil {
+		return err
+	}
+
+	if statusCode < 200 || statusCode > 299 {
+		return errNoSuccess
+	}
+
+	if isErrorResponse(body) {
+		return GetErrorFromResponse(body)
+	}
+
+	return nil
+}
+
+// ListWebhooks lists alll webhooks
+func (api *API) ListWebhooks(addrHash hash.Hash) ([]webhook.Type, error) {
+	url := fmt.Sprintf("/account/%s/webhook", addrHash.String())
+	body, statusCode, err := api.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	if statusCode < 200 || statusCode > 299 {
+		return nil, errNoSuccess
+	}
+
+	if isErrorResponse(body) {
+		return nil, GetErrorFromResponse(body)
+	}
+
+	// Parse body for webhooks
+	webhooks := []webhook.Type{}
+	err = json.Unmarshal(body, &webhooks)
+	if err != nil {
+		return nil, err
+	}
+
+	return webhooks, nil
+}
+
+// UpdateWebhook will update a webhook
+func (api *API) UpdateWebhook(addrHash hash.Hash, ID string, wh webhook.Type) error {
+	if wh.ID != ID {
+		return errNoSuccess
+	}
+
+	data, err := json.Marshal(wh)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("/account/%s/webhook/%s", addrHash.String(), ID)
+	body, statusCode, err := api.Post(url, data)
+	if err != nil {
+		return err
+	}
+
+	if statusCode < 200 || statusCode > 299 {
+		return errNoSuccess
+	}
+
+	if isErrorResponse(body) {
+		return GetErrorFromResponse(body)
+	}
+
+	return nil
+}
+
+// GetWebhook gets a single webhook
+func (api *API) GetWebhook(addrHash hash.Hash, ID string) (*webhook.Type, error) {
+	url := fmt.Sprintf("/account/%s/webhook/%s", addrHash.String(), ID)
+	body, statusCode, err := api.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	if statusCode < 200 || statusCode > 299 {
+		return nil, errNoSuccess
+	}
+
+	if isErrorResponse(body) {
+		return nil, GetErrorFromResponse(body)
+	}
+
+	// Parse body for webhook
+	wh := &webhook.Type{}
+	err = json.Unmarshal(body, &wh)
+	if err != nil {
+		return nil, err
+	}
+
+	return wh, nil
+}
+
+// EnableWebhook will enable a webhook
+func (api *API) EnableWebhook(addrHash hash.Hash, ID string) error {
+	url := fmt.Sprintf("/account/%s/webhook/%s/enable", addrHash.String(), ID)
+	body, statusCode, err := api.Post(url, []byte{})
+	if err != nil {
+		return err
+	}
+
+	if statusCode < 200 || statusCode > 299 {
+		return errNoSuccess
+	}
+
+	if isErrorResponse(body) {
+		return GetErrorFromResponse(body)
+	}
+
+	return nil
+}
+
+// DisableWebhook will disable a webhook
+func (api *API) DisableWebhook(addrHash hash.Hash, ID string) error {
+	url := fmt.Sprintf("/account/%s/webhook/%s/disable", addrHash.String(), ID)
+	body, statusCode, err := api.Post(url, []byte{})
+	if err != nil {
+		return err
+	}
+
+	if statusCode < 200 || statusCode > 299 {
+		return errNoSuccess
+	}
+
+	if isErrorResponse(body) {
+		return GetErrorFromResponse(body)
+	}
+
+	return nil
+}

--- a/internal/api/webhook.go
+++ b/internal/api/webhook.go
@@ -28,29 +28,31 @@ import (
 )
 
 // CreateWebhook Create a new API key
-func (api *API) CreateWebhook(wh webhook.Type) error {
+func (api *API) CreateWebhook(wh webhook.Type) (*webhook.Type, error) {
 	// ID is set by the server
 	wh.ID = ""
 	data, err := json.Marshal(wh)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	url := fmt.Sprintf("/account/%s/webhook", wh.Account.String())
 	body, statusCode, err := api.Post(url, data)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if statusCode < 200 || statusCode > 299 {
-		return errNoSuccess
+		return nil, errNoSuccess
 	}
 
 	if isErrorResponse(body) {
-		return GetErrorFromResponse(body)
+		return nil, GetErrorFromResponse(body)
 	}
 
-	return nil
+	fmt.Println(body)
+
+	return &wh, nil
 }
 
 // DeleteWebhook deletes a webhook

--- a/internal/config/config_server.go
+++ b/internal/config/config_server.go
@@ -72,6 +72,10 @@ type ServerConfig struct {
 		Enabled bool `yaml:"remote_enabled"`
 	} `yaml:"management"`
 
+	Webhooks struct {
+		Enabled bool `yaml:"enabled"`
+	} `yaml:"webhooks"`
+
 	Acme struct {
 		Enabled         bool   `yaml:"enabled"`
 		Domain          string `yaml:"domain"`

--- a/internal/config/config_server.go
+++ b/internal/config/config_server.go
@@ -73,7 +73,9 @@ type ServerConfig struct {
 	} `yaml:"management"`
 
 	Webhooks struct {
-		Enabled bool `yaml:"enabled"`
+		Enabled bool   `yaml:"enabled"`
+		System  string `yaml:"system"`
+		Workers int    `yaml:"workers"`
 	} `yaml:"webhooks"`
 
 	Acme struct {

--- a/internal/config/config_templates.go
+++ b/internal/config/config_templates.go
@@ -135,9 +135,13 @@ config:
         # When enabled, allow remote management through HTTPS instead of only local bm-config
         remote_enabled: false
 
-	webhooks:
-		# When enabled, users can add webhooks to their accounts
-		enabled: false
+    webhooks:
+        # When enabled, users can add webhooks to their accounts
+        enabled: false
+        # Set to "default" to use the default internal worker system
+        system: default
+        # workers is the amount of standby workers that will deal with webhook events
+        workers: 10
 
     bolt:
         # BoltDB database directory path to store the databases used for internal storage

--- a/internal/config/config_templates.go
+++ b/internal/config/config_templates.go
@@ -135,6 +135,10 @@ config:
         # When enabled, allow remote management through HTTPS instead of only local bm-config
         remote_enabled: false
 
+	webhooks:
+		# When enabled, users can add webhooks to their accounts
+		enabled: false
+
     bolt:
         # BoltDB database directory path to store the databases used for internal storage
         database_path: "~/.bitmaelum/database"

--- a/internal/container/bitmaelum.go
+++ b/internal/container/bitmaelum.go
@@ -24,6 +24,7 @@ import (
 	"github.com/bitmaelum/bitmaelum-suite/internal/resolver"
 	"github.com/bitmaelum/bitmaelum-suite/internal/subscription"
 	"github.com/bitmaelum/bitmaelum-suite/internal/ticket"
+	"github.com/bitmaelum/bitmaelum-suite/internal/webhook"
 )
 
 // Instance is the main bitmaelum service container
@@ -55,4 +56,9 @@ func (c *Type) GetSubscriptionRepo() subscription.Repository {
 // GetTicketRepo will return the current ticket repository
 func (c *Type) GetTicketRepo() ticket.Repository {
 	return c.Get("ticket").(ticket.Repository)
+}
+
+// GetWebhookRepo will return the current webhook repository
+func (c *Type) GetWebhookRepo() webhook.Repository {
+	return c.Get("webhook").(webhook.Repository)
 }

--- a/internal/container/webhook.go
+++ b/internal/container/webhook.go
@@ -55,7 +55,7 @@ func setupWebhookRepo() (interface{}, error) {
 		webhookRepository = webhook.NewBoltRepository(config.Server.Bolt.DatabasePath)
 	})
 
-	return webhookRepository, nil
+	return *webhookRepository, nil
 }
 
 func init() {

--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -67,7 +67,7 @@ func dispatch(h hash.Hash, evt webhook.EventEnum, payload map[string]interface{}
 		payload["meta"] = map[string]string{
 			"id":      wh.ID,
 			"account": wh.Account.String(),
-			"event":   evt.String(),    // We need to use the event, otherwise we might end up with event "all"
+			"event":   evt.String(), // We need to use the event, otherwise we might end up with event "all"
 		}
 
 		wh := wh
@@ -80,31 +80,34 @@ func dispatch(h hash.Hash, evt webhook.EventEnum, payload map[string]interface{}
 	return nil
 }
 
+// DispatchRemoteDelivery dispatches event
 func DispatchRemoteDelivery(h hash.Hash, header *message.Header, msgID string) error {
 	payload := map[string]interface{}{
 		"message": map[string]string{
-			"from":       header.From.Addr.String(),
-			"to":         header.To.Addr.String(),
-			"id": msgID,
+			"from": header.From.Addr.String(),
+			"to":   header.To.Addr.String(),
+			"id":   msgID,
 		},
 	}
 
 	return dispatch(h, webhook.EventLocalDelivery, payload)
 }
 
+// DispatchLocalDelivery dispatches event
 func DispatchLocalDelivery(h hash.Hash, header *message.Header, msgID string) error {
 	payload := map[string]interface{}{
 		"message": map[string]string{
-			"from":       header.From.Addr.String(),
-			"to":         header.To.Addr.String(),
-			"id": msgID,
+			"from": header.From.Addr.String(),
+			"to":   header.To.Addr.String(),
+			"id":   msgID,
 		},
 	}
 
 	return dispatch(h, webhook.EventLocalDelivery, payload)
 }
 
-func DispatchApiKeyCreate(h hash.Hash, k key.APIKeyType) error {
+// DispatchAPIKeyCreate dispatches event
+func DispatchAPIKeyCreate(h hash.Hash, k key.APIKeyType) error {
 	payload := map[string]interface{}{
 		"key": k,
 	}
@@ -112,7 +115,8 @@ func DispatchApiKeyCreate(h hash.Hash, k key.APIKeyType) error {
 	return dispatch(h, webhook.EventAPIKeyCreated, payload)
 }
 
-func DispatchApiKeyDelete(h hash.Hash, k key.APIKeyType) error {
+// DispatchAPIKeyDelete dispatches event
+func DispatchAPIKeyDelete(h hash.Hash, k key.APIKeyType) error {
 	payload := map[string]interface{}{
 		"key": map[string]string{
 			"id": k.ID,
@@ -122,6 +126,7 @@ func DispatchApiKeyDelete(h hash.Hash, k key.APIKeyType) error {
 	return dispatch(h, webhook.EventAPIKeyDeleted, payload)
 }
 
+// DispatchAuthKeyCreate dispatches event
 func DispatchAuthKeyCreate(h hash.Hash, k key.AuthKeyType) error {
 	payload := map[string]interface{}{
 		"key": k,
@@ -130,6 +135,7 @@ func DispatchAuthKeyCreate(h hash.Hash, k key.AuthKeyType) error {
 	return dispatch(h, webhook.EventAuthKeyCreated, payload)
 }
 
+// DispatchAuthKeyDelete dispatches event
 func DispatchAuthKeyDelete(h hash.Hash, k key.AuthKeyType) error {
 	payload := map[string]interface{}{
 		"key": map[string]string{
@@ -140,6 +146,7 @@ func DispatchAuthKeyDelete(h hash.Hash, k key.AuthKeyType) error {
 	return dispatch(h, webhook.EventAuthKeyDeleted, payload)
 }
 
+// DispatchWebhookCreate dispatches event
 func DispatchWebhookCreate(h hash.Hash, wh webhook.Type) error {
 	payload := map[string]interface{}{
 		"webhook": wh,
@@ -148,6 +155,7 @@ func DispatchWebhookCreate(h hash.Hash, wh webhook.Type) error {
 	return dispatch(h, webhook.EventWebhookCreated, payload)
 }
 
+// DispatchWebhookUpdate dispatches event
 func DispatchWebhookUpdate(h hash.Hash, wh webhook.Type) error {
 	payload := map[string]interface{}{
 		"webhook": wh,
@@ -156,6 +164,7 @@ func DispatchWebhookUpdate(h hash.Hash, wh webhook.Type) error {
 	return dispatch(h, webhook.EventWebhookUpdated, payload)
 }
 
+// DispatchWebhookDelete dispatches event
 func DispatchWebhookDelete(h hash.Hash, wh webhook.Type) error {
 	payload := map[string]interface{}{
 		"webhook": map[string]string{

--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -90,7 +90,7 @@ func DispatchRemoteDelivery(h hash.Hash, header *message.Header, msgID string) e
 		},
 	}
 
-	return dispatch(h, webhook.EventLocalDelivery, payload)
+	return dispatch(h, webhook.EventRemoteDelivery, payload)
 }
 
 // DispatchLocalDelivery dispatches event

--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -20,8 +20,6 @@
 package dispatcher
 
 import (
-	"encoding/json"
-
 	"github.com/bitmaelum/bitmaelum-suite/internal/container"
 	"github.com/bitmaelum/bitmaelum-suite/internal/key"
 	"github.com/bitmaelum/bitmaelum-suite/internal/message"
@@ -72,15 +70,10 @@ func dispatch(h hash.Hash, evt webhook.EventEnum, payload map[string]interface{}
 			"event":   evt.String(),    // We need to use the event, otherwise we might end up with event "all"
 		}
 
-		payloadBytes, err := json.Marshal(payload)
-		if err != nil {
-			continue
-		}
-
 		wh := wh
 		_ = dispatcher.Dispatch(func() {
 			logrus.Tracef("dispatching webhook %s", wh.ID)
-			work(wh, payloadBytes)
+			Work(wh, payload)
 		})
 	}
 

--- a/internal/dispatcher/worker.go
+++ b/internal/dispatcher/worker.go
@@ -39,7 +39,7 @@ func work(w webhook.Type, payload []byte) {
 
 func execHTTP(w webhook.Type, payload []byte) error {
 	cfg := &webhook.ConfigHTTP{}
-	err := json.Unmarshal([]byte(w.Config), cfg)
+	err := json.Unmarshal([]byte(w.Config), &cfg)
 	if err != nil {
 		return err
 	}

--- a/internal/dispatcher/worker.go
+++ b/internal/dispatcher/worker.go
@@ -33,13 +33,13 @@ import (
 func work(w webhook.Type, payload []byte) {
 	switch w.Type {
 	case webhook.TypeHTTP:
-		execHTTP(w, payload)
+		_ = execHTTP(w, payload)
 	}
 }
 
 func execHTTP(w webhook.Type, payload []byte) error {
 	cfg := &webhook.ConfigHTTP{}
-	err := json.Unmarshal(w.Config, cfg)
+	err := json.Unmarshal([]byte(w.Config), cfg)
 	if err != nil {
 		return err
 	}

--- a/internal/dispatcher/worker.go
+++ b/internal/dispatcher/worker.go
@@ -106,9 +106,6 @@ func execSlack(w webhook.Type, payload interface{}) error {
 		templateBody = cfg.Template
 	}
 
-	logrus.Trace("template: ", templateBody)
-	logrus.Trace("payload: ", payload)
-
 	tmpl, err := template.New("slack").Funcs(template.FuncMap{
 		"json": func(v interface{}) string {
 			b, err := json.MarshalIndent(v, "", "  ")

--- a/internal/dispatcher/worker.go
+++ b/internal/dispatcher/worker.go
@@ -37,11 +37,11 @@ import (
 var defaultSlackTemplate = `
 Event *{{.meta.event}}* for account *{{.meta.account}}*:
 
-`+"```"+`
+` + "```" + `
 {{json . -}}
-`+"```"
+` + "```"
 
-// work is the main function that will get dispatched as a job. It will do the actual work
+// Work is the main function that will get dispatched as a job. It will do the actual work of sending data
 func Work(w webhook.Type, payload interface{}) {
 	switch w.Type {
 	case webhook.TypeHTTP:
@@ -96,8 +96,8 @@ func execSlack(w webhook.Type, payload interface{}) error {
 	if cfg.IconEmoji != "" {
 		slackPayload["icon_emoji"] = cfg.IconEmoji
 	}
-	if cfg.IconUrl != "" {
-		slackPayload["icon_url"] = cfg.IconUrl
+	if cfg.IconURL != "" {
+		slackPayload["icon_url"] = cfg.IconURL
 	}
 
 	// Create text from (default) template and webhook payload
@@ -110,7 +110,7 @@ func execSlack(w webhook.Type, payload interface{}) error {
 	logrus.Trace("payload: ", payload)
 
 	tmpl, err := template.New("slack").Funcs(template.FuncMap{
-		"json": func (v interface{}) string {
+		"json": func(v interface{}) string {
 			b, err := json.MarshalIndent(v, "", "  ")
 			if err != nil {
 				return ""
@@ -131,7 +131,6 @@ func execSlack(w webhook.Type, payload interface{}) error {
 		return err
 	}
 	slackPayload["text"] = sb.String()
-
 
 	// Post slack payload
 	slackPayloadBytes, err := json.Marshal(slackPayload)

--- a/internal/duration.go
+++ b/internal/duration.go
@@ -21,7 +21,6 @@ package internal
 
 import (
 	"errors"
-	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -56,7 +55,6 @@ func ParseDuration(s string) (time.Duration, error) {
 	if len(matches) == 0 {
 		return time.Duration(0), errInvalidFormat
 	}
-	fmt.Println(matches)
 
 	d := 0
 	found := ""

--- a/internal/editor.go
+++ b/internal/editor.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package internal
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"os"
+	"os/exec"
+)
+
+// OpenJSONFileEditor will open a text editor where you can manually edit the given src json
+func OpenJSONFileEditor(src interface{}, dst interface{}) error {
+	// Create a temp file
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "bmtmpedit-")
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		_ = os.Remove(tmpFile.Name())
+	}()
+
+	// Write our json data to the temp file
+	data, _ := json.MarshalIndent(src, "", "  ")
+	_, err = tmpFile.Write(data)
+	_ = tmpFile.Sync()
+	if err != nil {
+		return err
+	}
+
+	editor, err := getEditor()
+	if err != nil {
+		return err
+	}
+
+	for {
+		// Execute editor
+		c := exec.Command(editor, tmpFile.Name())
+		c.Stdin = os.Stdin
+		c.Stdout = os.Stdout
+		err = c.Run()
+		if err != nil {
+			return err
+		}
+
+		// Editor errored
+		if !c.ProcessState.Success() {
+			return err
+		}
+
+		data, err = ioutil.ReadFile(tmpFile.Name())
+		if err != nil {
+			return err
+		}
+
+		err = json.Unmarshal(data, dst)
+		if err != nil || dst == nil {
+			// Something is not right with unmarshalling. Let the user try and edit the file again
+			continue
+		}
+
+		// All is good, return
+		return nil
+	}
+}
+
+// Get default editor
+func getEditor() (string, error) {
+	if os.Getenv("EDITOR") != "" {
+		return os.Getenv("EDITOR"), nil
+	}
+
+	editors := []string{"/usr/bin/editor", "/usr/bin/nano"}
+	for _, editor := range editors {
+		_, err := os.Stat(editor)
+		if err == nil {
+			return editor, nil
+		}
+	}
+
+	return "", errors.New("no editor found")
+}

--- a/internal/webhook/bolt.go
+++ b/internal/webhook/bolt.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package webhook
+
+import (
+	"encoding/json"
+
+	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
+	"github.com/sirupsen/logrus"
+	bolt "go.etcd.io/bbolt"
+)
+
+type boltRepo struct {
+	client     *bolt.DB
+	BucketName string
+}
+
+// BoltDBFile is the filename to store the boltdb database
+const BoltDBFile = "webhooks.db"
+
+func (b boltRepo) FetchByHash(h hash.Hash) ([]Type, error) {
+	var webhooks []Type
+
+	err := b.client.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(b.BucketName))
+		if bucket == nil {
+			logrus.Trace("webhooks for account not found in BOLT: ", h, nil)
+			return errWebhookNotFound
+		}
+
+		c := bucket.Cursor()
+		for k, data := c.First(); k != nil; k, data = c.Next() {
+			w := Type{}
+			err := json.Unmarshal(data, &w)
+			if err != nil {
+				continue
+			}
+
+			if w.Account.String() == h.String() {
+				webhooks = append(webhooks, w)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return webhooks, nil
+}
+
+
+// Fetch a key from the repository, or err
+func (b boltRepo) Fetch(ID string) (*Type, error) {
+	w := &Type{}
+
+	err := b.client.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(b.BucketName))
+		if bucket == nil {
+			logrus.Trace("webhook not found in storage")
+			return errWebhookNotFound
+		}
+
+		data := bucket.Get([]byte(ID))
+		if data == nil {
+			logrus.Trace("webhook not found in storage")
+			return errWebhookNotFound
+		}
+
+		err := json.Unmarshal([]byte(data), w)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
+// Store the given key in the repository
+func (b boltRepo) Store(w Type) error {
+	data, err := json.Marshal(w)
+	if err != nil {
+		return err
+	}
+
+	err = b.client.Update(func(tx *bolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists([]byte(b.BucketName))
+		if err != nil {
+			logrus.Trace("unable to create bucket on BOLT: ", b.BucketName, err)
+			return err
+		}
+
+		return bucket.Put([]byte(w.ID), data)
+	})
+
+	return err
+}
+
+// Remove the given key from the repository
+func (b boltRepo) Remove(w Type) error {
+	return b.client.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(b.BucketName))
+		if bucket == nil {
+			logrus.Trace("unable to delete apikey, apikey not found in BOLT: ", w.ID, nil)
+			return nil
+		}
+
+		return bucket.Delete([]byte(w.ID))
+	})
+}

--- a/internal/webhook/bolt.go
+++ b/internal/webhook/bolt.go
@@ -62,7 +62,7 @@ func (b boltRepo) FetchByHash(h hash.Hash) ([]Type, error) {
 	})
 
 	if err != nil {
-		return nil, err
+		return []Type{}, err
 	}
 
 	return webhooks, nil

--- a/internal/webhook/bolt.go
+++ b/internal/webhook/bolt.go
@@ -68,7 +68,6 @@ func (b boltRepo) FetchByHash(h hash.Hash) ([]Type, error) {
 	return webhooks, nil
 }
 
-
 // Fetch a key from the repository, or err
 func (b boltRepo) Fetch(ID string) (*Type, error) {
 	w := &Type{}

--- a/internal/webhook/events.go
+++ b/internal/webhook/events.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package webhook
+
+import (
+	"errors"
+	"strings"
+)
+
+// EventEnum is the event on which the webhook responds
+type EventEnum int
+
+// Webhook event types. Everything that a webhook can trigger on
+const (
+	EventLocalDelivery  EventEnum = iota + 1 // A local delivery has been made (incoming)
+	EventFailedDelivery                      // A message is received but not considered correct
+	EventRemoveDelivery                      // A message has been send to a remote server (outgoing)
+	EventApiKeyCreated                       // Api Key created
+	EventApiKeyDeleted                       // Api key deleted
+	EventApiKeyUpdated                       // Api key updated
+	EventAuthKeyCreated                      // Auth key created
+	EventAuthKeyDeleted                      // Auth key deleted
+	EventAuthKeyUpdated                      // Auth key updated
+	EventWebhookCreated                      // webhook created
+	EventWebhookDeleted                      // webhook deleted
+	EventWebhookUpdated                      // webhook updated
+	EventInviteCreated                       // invite created
+	EventAccountCreated                      // account created
+	EventAll            EventEnum = 999      // All events
+)
+
+var EventLabels = map[string]EventEnum{
+	"all":            EventAll,
+	"localdelivery":  EventLocalDelivery,
+	"faileddelivery": EventFailedDelivery,
+	"remotedelivery": EventRemoveDelivery,
+	"apikeycreated":  EventApiKeyCreated,
+	"apikeydeleted":  EventApiKeyDeleted,
+	"apikeyupdated":  EventApiKeyUpdated,
+	"authkeycreated": EventAuthKeyCreated,
+	"authkeydeleted": EventAuthKeyDeleted,
+	"authkeyupdated": EventAuthKeyUpdated,
+	"webhookcreated": EventWebhookCreated,
+	"webhookdeleted": EventWebhookDeleted,
+	"webhookupdated": EventWebhookUpdated,
+	"invitecreated":  EventInviteCreated,
+	"accountcreated": EventAccountCreated,
+}
+
+// String convert event to string
+func (e EventEnum) String() string {
+	for l, ev := range EventLabels {
+		if ev == e {
+			return l
+		}
+	}
+
+	return ""
+}
+
+func NewEventFromString(s string) (EventEnum, error) {
+	for l, ev := range EventLabels {
+		if strings.ToLower(s) == l {
+			return ev, nil
+		}
+	}
+
+	return 0, errors.New("unknown event type")
+}

--- a/internal/webhook/events.go
+++ b/internal/webhook/events.go
@@ -32,9 +32,9 @@ const (
 	EventLocalDelivery  EventEnum = iota + 1 // A local delivery has been made (incoming)
 	EventFailedDelivery                      // A message is received but not considered correct
 	EventRemoveDelivery                      // A message has been send to a remote server (outgoing)
-	EventApiKeyCreated                       // Api Key created
-	EventApiKeyDeleted                       // Api key deleted
-	EventApiKeyUpdated                       // Api key updated
+	EventAPIKeyCreated                       // Api Key created
+	EventAPIKeyDeleted                       // Api key deleted
+	EventAPIKeyUpdated                       // Api key updated
 	EventAuthKeyCreated                      // Auth key created
 	EventAuthKeyDeleted                      // Auth key deleted
 	EventAuthKeyUpdated                      // Auth key updated
@@ -46,14 +46,15 @@ const (
 	EventAll            EventEnum = 999      // All events
 )
 
+// EventLabels is the mapping of an event to a string or string to event
 var EventLabels = map[string]EventEnum{
 	"all":            EventAll,
 	"localdelivery":  EventLocalDelivery,
 	"faileddelivery": EventFailedDelivery,
 	"remotedelivery": EventRemoveDelivery,
-	"apikeycreated":  EventApiKeyCreated,
-	"apikeydeleted":  EventApiKeyDeleted,
-	"apikeyupdated":  EventApiKeyUpdated,
+	"apikeycreated":  EventAPIKeyCreated,
+	"apikeydeleted":  EventAPIKeyDeleted,
+	"apikeyupdated":  EventAPIKeyUpdated,
 	"authkeycreated": EventAuthKeyCreated,
 	"authkeydeleted": EventAuthKeyDeleted,
 	"authkeyupdated": EventAuthKeyUpdated,
@@ -75,6 +76,7 @@ func (e EventEnum) String() string {
 	return ""
 }
 
+// NewEventFromString will create a new event based on the string
 func NewEventFromString(s string) (EventEnum, error) {
 	for l, ev := range EventLabels {
 		if strings.ToLower(s) == l {

--- a/internal/webhook/events.go
+++ b/internal/webhook/events.go
@@ -43,6 +43,7 @@ const (
 	EventWebhookUpdated                      // webhook updated
 	EventInviteCreated                       // invite created
 	EventAccountCreated                      // account created
+	EventTest           EventEnum = 998      // Test event
 	EventAll            EventEnum = 999      // All events
 )
 
@@ -63,6 +64,7 @@ var EventLabels = map[string]EventEnum{
 	"webhookupdated": EventWebhookUpdated,
 	"invitecreated":  EventInviteCreated,
 	"accountcreated": EventAccountCreated,
+	"test":           EventTest,
 }
 
 // String convert event to string

--- a/internal/webhook/events.go
+++ b/internal/webhook/events.go
@@ -31,7 +31,7 @@ type EventEnum int
 const (
 	EventLocalDelivery  EventEnum = iota + 1 // A local delivery has been made (incoming)
 	EventFailedDelivery                      // A message is received but not considered correct
-	EventRemoveDelivery                      // A message has been send to a remote server (outgoing)
+	EventRemoteDelivery                      // A message has been send to a remote server (outgoing)
 	EventAPIKeyCreated                       // Api Key created
 	EventAPIKeyDeleted                       // Api key deleted
 	EventAPIKeyUpdated                       // Api key updated
@@ -51,7 +51,7 @@ var EventLabels = map[string]EventEnum{
 	"all":            EventAll,
 	"localdelivery":  EventLocalDelivery,
 	"faileddelivery": EventFailedDelivery,
-	"remotedelivery": EventRemoveDelivery,
+	"remotedelivery": EventRemoteDelivery,
 	"apikeycreated":  EventAPIKeyCreated,
 	"apikeydeleted":  EventAPIKeyDeleted,
 	"apikeyupdated":  EventAPIKeyUpdated,

--- a/internal/webhook/mock.go
+++ b/internal/webhook/mock.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package webhook
+
+import (
+	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
+)
+
+type mockRepo struct {
+	Webhooks map[string]Type
+}
+
+// FetchByHash will retrieve all keys for the given account
+func (r mockRepo) FetchByHash(h hash.Hash) ([]Type, error) {
+	var webhooks []Type
+
+	for _, w := range r.Webhooks {
+		if w.Account.String() == h.String() {
+			webhooks = append(webhooks, w)
+		}
+	}
+
+	return webhooks, nil
+}
+
+// Fetch a key from the repository, or err
+func (r mockRepo) Fetch(ID string) (*Type, error) {
+	w, ok := r.Webhooks[ID]
+	if !ok {
+		return nil, errWebhookNotFound
+	}
+
+	return &w, nil
+}
+
+// Store the given key in the repository
+func (r mockRepo) Store(w Type) error {
+	r.Webhooks[w.ID] = w
+	return nil
+}
+
+// Remove the given key from the repository
+func (r mockRepo) Remove(w Type) error {
+	delete(r.Webhooks, w.ID)
+	return nil
+}

--- a/internal/webhook/mock_test.go
+++ b/internal/webhook/mock_test.go
@@ -31,11 +31,11 @@ func TestMockRepo(t *testing.T) {
 	repo := NewMockRepository()
 
 	cfg := ConfigHTTP{
-		Url: "https://foo.bar/test",
+		URL: "https://foo.bar/test",
 	}
 	data, _ := json.Marshal(cfg)
 
-	w, err := NewWebhook(hash.New("example!"), TypeHTTP, EventNewMessage, data)
+	w, err := NewWebhook(hash.New("example!"), EventNewMessage, TypeHTTP, data)
 	assert.NoError(t, err)
 
 	err = repo.Store(*w)
@@ -48,12 +48,8 @@ func TestMockRepo(t *testing.T) {
 	assert.Equal(t, TypeHTTP, w2.Type)
 	assert.Equal(t, "2e4551de804e27aacf20f9df5be3e8cd384ed64488b21ab079fb58e8c90068ab", w2.Account.String())
 
-	cfg = ConfigHTTP{
-		Url: "https://example.org",
-	}
-
 	h := hash.New("example!")
-	w, err = NewWebhook(hash.New("example!"), TypeHTTP, EventNewMessage, data)
+	w, err = NewWebhook(hash.New("example!"), EventNewMessage, TypeHTTP, data)
 	assert.NoError(t, err)
 	err = repo.Store(*w)
 	assert.NoError(t, err)

--- a/internal/webhook/mock_test.go
+++ b/internal/webhook/mock_test.go
@@ -20,7 +20,6 @@
 package webhook
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
@@ -35,9 +34,8 @@ func TestMockRepo(t *testing.T) {
 	cfg := ConfigHTTP{
 		URL: "https://foo.bar/test",
 	}
-	data, _ := json.Marshal(cfg)
 
-	w, err := NewWebhook(exampleHash, EventLocalDelivery, TypeHTTP, data)
+	w, err := NewWebhook(exampleHash, EventLocalDelivery, TypeHTTP, cfg)
 	assert.NoError(t, err)
 
 	err = repo.Store(*w)
@@ -50,7 +48,7 @@ func TestMockRepo(t *testing.T) {
 	assert.Equal(t, TypeHTTP, w2.Type)
 	assert.Equal(t, "2e4551de804e27aacf20f9df5be3e8cd384ed64488b21ab079fb58e8c90068ab", w2.Account.String())
 
-	w, err = NewWebhook(exampleHash, EventLocalDelivery, TypeHTTP, data)
+	w, err = NewWebhook(exampleHash, EventLocalDelivery, TypeHTTP, cfg)
 	assert.NoError(t, err)
 	err = repo.Store(*w)
 	assert.NoError(t, err)

--- a/internal/webhook/mock_test.go
+++ b/internal/webhook/mock_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var exampleHash = hash.New("example!")
+
 func TestMockRepo(t *testing.T) {
 	repo := NewMockRepository()
 
@@ -35,7 +37,7 @@ func TestMockRepo(t *testing.T) {
 	}
 	data, _ := json.Marshal(cfg)
 
-	w, err := NewWebhook(hash.New("example!"), EventNewMessage, TypeHTTP, data)
+	w, err := NewWebhook(exampleHash, EventLocalDelivery, TypeHTTP, data)
 	assert.NoError(t, err)
 
 	err = repo.Store(*w)
@@ -44,17 +46,16 @@ func TestMockRepo(t *testing.T) {
 	w2, err := repo.Fetch(w.ID)
 	assert.NoError(t, err)
 	assert.False(t, w2.Enabled)
-	assert.Equal(t, EventNewMessage, w2.Event)
+	assert.Equal(t, EventLocalDelivery, w2.Event)
 	assert.Equal(t, TypeHTTP, w2.Type)
 	assert.Equal(t, "2e4551de804e27aacf20f9df5be3e8cd384ed64488b21ab079fb58e8c90068ab", w2.Account.String())
 
-	h := hash.New("example!")
-	w, err = NewWebhook(hash.New("example!"), EventNewMessage, TypeHTTP, data)
+	w, err = NewWebhook(exampleHash, EventLocalDelivery, TypeHTTP, data)
 	assert.NoError(t, err)
 	err = repo.Store(*w)
 	assert.NoError(t, err)
 
-	hooks, err := repo.FetchByHash(h)
+	hooks, err := repo.FetchByHash(exampleHash)
 	assert.NoError(t, err)
 	assert.Len(t, hooks, 2)
 	assert.NotEqual(t, hooks[0].ID, hooks[1].ID)
@@ -63,7 +64,7 @@ func TestMockRepo(t *testing.T) {
 	err = repo.Remove(*w)
 	assert.NoError(t, err)
 
-	hooks, err = repo.FetchByHash(h)
+	hooks, err = repo.FetchByHash(exampleHash)
 	assert.NoError(t, err)
 	assert.Len(t, hooks, 1)
 }

--- a/internal/webhook/mock_test.go
+++ b/internal/webhook/mock_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package webhook
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockRepo(t *testing.T) {
+	repo := NewMockRepository()
+
+	cfg := ConfigHTTP{
+		Url: "https://foo.bar/test",
+	}
+	data, _ := json.Marshal(cfg)
+
+	w, err := NewWebhook(hash.New("example!"), TypeHTTP, EventNewMessage, data)
+	assert.NoError(t, err)
+
+	err = repo.Store(*w)
+	assert.NoError(t, err)
+
+	w2, err := repo.Fetch(w.ID)
+	assert.NoError(t, err)
+	assert.False(t, w2.Enabled)
+	assert.Equal(t, EventNewMessage, w2.Event)
+	assert.Equal(t, TypeHTTP, w2.Type)
+	assert.Equal(t, "2e4551de804e27aacf20f9df5be3e8cd384ed64488b21ab079fb58e8c90068ab", w2.Account.String())
+
+	cfg = ConfigHTTP{
+		Url: "https://example.org",
+	}
+
+	h := hash.New("example!")
+	w, err = NewWebhook(hash.New("example!"), TypeHTTP, EventNewMessage, data)
+	assert.NoError(t, err)
+	err = repo.Store(*w)
+	assert.NoError(t, err)
+
+	hooks, err := repo.FetchByHash(h)
+	assert.NoError(t, err)
+	assert.Len(t, hooks, 2)
+	assert.NotEqual(t, hooks[0].ID, hooks[1].ID)
+	assert.Equal(t, hooks[0].Account.String(), hooks[1].Account.String())
+
+	err = repo.Remove(*w)
+	assert.NoError(t, err)
+
+	hooks, err = repo.FetchByHash(h)
+	assert.NoError(t, err)
+	assert.Len(t, hooks, 1)
+}

--- a/internal/webhook/redis.go
+++ b/internal/webhook/redis.go
@@ -43,8 +43,6 @@ func (r redisRepo) FetchByHash(h hash.Hash) ([]Type, error) {
 	}
 
 	var webhooks []Type
-	{
-	}
 
 	for _, item := range items {
 		w, err := r.Fetch(item)

--- a/internal/webhook/redis.go
+++ b/internal/webhook/redis.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/bitmaelum/bitmaelum-suite/internal"
+	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
+)
+
+type redisRepo struct {
+	client    internal.RedisResultWrapper
+	context   context.Context
+	KeyPrefix string // redis key prefix
+}
+
+// FetchByHash will retrieve all hooks for the given account
+func (r redisRepo) FetchByHash(h hash.Hash) ([]Type, error) {
+
+	items, err := r.client.SMembers(r.context, r.createRedisKey(h.String()))
+	if err != nil {
+		return nil, errWebhookNotFound
+	}
+
+	var webhooks []Type
+	{
+	}
+
+	for _, item := range items {
+		w, err := r.Fetch(item)
+		if err != nil {
+			continue
+		}
+
+		webhooks = append(webhooks, *w)
+	}
+
+	return webhooks, nil
+}
+
+// Fetch a key from the repository, or err
+func (r redisRepo) Fetch(ID string) (*Type, error) {
+	data, err := r.client.Get(r.context, r.createRedisKey(ID))
+	if data == "" || err != nil {
+		return nil, errWebhookNotFound
+	}
+
+	w := &Type{}
+	err = json.Unmarshal([]byte(data), w)
+	if err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
+// Store the given key in the repository
+func (r redisRepo) Store(w Type) error {
+	data, err := json.Marshal(w)
+	if err != nil {
+		return err
+	}
+
+	// Add to account set
+	_, _ = r.client.SAdd(r.context, r.createRedisKey(w.Account.String()), w.ID)
+
+	_, err = r.client.Set(r.context, r.createRedisKey(w.ID), data, 0)
+	return err
+}
+
+// Remove the given key from the repository
+func (r redisRepo) Remove(w Type) error {
+	// Remove from account set
+	_, _ = r.client.SRem(r.context, r.createRedisKey(w.Account.String()), w.ID)
+
+	_, err := r.client.Del(r.context, r.createRedisKey(w.ID))
+	return err
+}
+
+// createRedisKey creates a key based on the given ID. This is needed otherwise we might send any data as webhook-id
+// to redis in order to extract other kind of data (and you don't want that).
+func (r redisRepo) createRedisKey(id string) string {
+	return fmt.Sprintf("%s-%s", r.KeyPrefix, id)
+}

--- a/internal/webhook/redis.go
+++ b/internal/webhook/redis.go
@@ -39,7 +39,7 @@ func (r redisRepo) FetchByHash(h hash.Hash) ([]Type, error) {
 
 	items, err := r.client.SMembers(r.context, r.createRedisKey(h.String()))
 	if err != nil {
-		return nil, errWebhookNotFound
+		return []Type{}, errWebhookNotFound
 	}
 
 	var webhooks []Type

--- a/internal/webhook/redis_test.go
+++ b/internal/webhook/redis_test.go
@@ -37,7 +37,7 @@ func TestRedis(t *testing.T) {
 		context: context.Background(),
 	}
 
-	repo := &WebhookRepository{
+	repo := &Repository{
 		storageRepo: storage,
 	}
 
@@ -46,12 +46,12 @@ func TestRedis(t *testing.T) {
 	)
 
 	cfg := ConfigHTTP{
-		Url: "https://foo.bar/test",
+		URL: "https://foo.bar/test",
 	}
 	data, _ := json.Marshal(cfg)
 
 	h1 := hash.Hash("set 1")
-	w, err := NewWebhook(h1, TypeHTTP, EventNewMessage, data)
+	w, _ := NewWebhook(h1, EventNewMessage, TypeHTTP, data)
 
 	m.Queue("set", "ok", nil)
 	m.Queue("sadd", int64(1), nil)
@@ -75,19 +75,19 @@ func TestRedis(t *testing.T) {
 	assert.Nil(t, kt2)
 
 	/*
-	m.Queue("smembers", []string{"foo", "bar"}, nil)
-	m.Queue("get", "{\"key\":\"abc\",\"valid_until\":\"0001-01-01T00:00:00Z\",\"permissions\":[\"foobar\"],\"admin\":true,\"address_hash\":\"set 1\",\"description\":\"test key\"}", nil)
-	m.Queue("get", "{\"key\":\"def\",\"valid_until\":\"0001-01-01T00:00:00Z\",\"permissions\":[\"foobar\"],\"admin\":true,\"address_hash\":\"set 1\",\"description\":\"test key 2\"}", nil)
-	kts, err = repo.FetchByHash("set 1")
-	assert.NoError(t, err)
-	assert.Len(t, kts, 2)
-	assert.Equal(t, "abc", kts[0].ID)
-	assert.Equal(t, "def", kts[1].ID)
+		m.Queue("smembers", []string{"foo", "bar"}, nil)
+		m.Queue("get", "{\"key\":\"abc\",\"valid_until\":\"0001-01-01T00:00:00Z\",\"permissions\":[\"foobar\"],\"admin\":true,\"address_hash\":\"set 1\",\"description\":\"test key\"}", nil)
+		m.Queue("get", "{\"key\":\"def\",\"valid_until\":\"0001-01-01T00:00:00Z\",\"permissions\":[\"foobar\"],\"admin\":true,\"address_hash\":\"set 1\",\"description\":\"test key 2\"}", nil)
+		kts, err = repo.FetchByHash("set 1")
+		assert.NoError(t, err)
+		assert.Len(t, kts, 2)
+		assert.Equal(t, "abc", kts[0].ID)
+		assert.Equal(t, "def", kts[1].ID)
 
-	m.Queue("srem", int64(1), nil)
-	m.Queue("del", int64(1), nil)
-	err = repo.Remove(*kt)
-	assert.NoError(t, err)
+		m.Queue("srem", int64(1), nil)
+		m.Queue("del", int64(1), nil)
+		err = repo.Remove(*kt)
+		assert.NoError(t, err)
 	*/
 }
 

--- a/internal/webhook/redis_test.go
+++ b/internal/webhook/redis_test.go
@@ -51,7 +51,7 @@ func TestRedis(t *testing.T) {
 	data, _ := json.Marshal(cfg)
 
 	h1 := hash.Hash("set 1")
-	w, _ := NewWebhook(h1, EventNewMessage, TypeHTTP, data)
+	w, _ := NewWebhook(h1, EventLocalDelivery, TypeHTTP, data)
 
 	m.Queue("set", "ok", nil)
 	m.Queue("sadd", int64(1), nil)

--- a/internal/webhook/redis_test.go
+++ b/internal/webhook/redis_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	testing2 "github.com/bitmaelum/bitmaelum-suite/internal/testing"
+	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedis(t *testing.T) {
+	m := &testing2.RedisClientMock{}
+
+	storage := redisRepo{
+		client:  m,
+		context: context.Background(),
+	}
+
+	repo := &WebhookRepository{
+		storageRepo: storage,
+	}
+
+	var (
+		err error
+	)
+
+	cfg := ConfigHTTP{
+		Url: "https://foo.bar/test",
+	}
+	data, _ := json.Marshal(cfg)
+
+	h1 := hash.Hash("set 1")
+	w, err := NewWebhook(h1, TypeHTTP, EventNewMessage, data)
+
+	m.Queue("set", "ok", nil)
+	m.Queue("sadd", int64(1), nil)
+	err = repo.Store(*w)
+	assert.NoError(t, err)
+
+	m.Queue("get", "{\"ID\":\"1721c5e1-892a-4a0c-b5bf-cedcab46f3cd\",\"Account\":\"set 1\",\"Type\":0,\"Event\":1,\"Enabled\":false,\"Config\":\"eyJVcmwiOiJodHRwczovL2Zvby5iYXIvdGVzdCJ9\"}", nil)
+	kt2, err := repo.Fetch("abc")
+	assert.NoError(t, err)
+	assert.Equal(t, "1721c5e1-892a-4a0c-b5bf-cedcab46f3cd", kt2.ID)
+	assert.Equal(t, "set 1", kt2.Account.String())
+
+	m.Queue("get", "", errWebhookNotFound)
+	kt2, err = repo.Fetch("efg")
+	assert.Error(t, err)
+	assert.Nil(t, kt2)
+
+	m.Queue("get", "notjson", nil)
+	kt2, err = repo.Fetch("efg")
+	assert.Error(t, err)
+	assert.Nil(t, kt2)
+
+	/*
+	m.Queue("smembers", []string{"foo", "bar"}, nil)
+	m.Queue("get", "{\"key\":\"abc\",\"valid_until\":\"0001-01-01T00:00:00Z\",\"permissions\":[\"foobar\"],\"admin\":true,\"address_hash\":\"set 1\",\"description\":\"test key\"}", nil)
+	m.Queue("get", "{\"key\":\"def\",\"valid_until\":\"0001-01-01T00:00:00Z\",\"permissions\":[\"foobar\"],\"admin\":true,\"address_hash\":\"set 1\",\"description\":\"test key 2\"}", nil)
+	kts, err = repo.FetchByHash("set 1")
+	assert.NoError(t, err)
+	assert.Len(t, kts, 2)
+	assert.Equal(t, "abc", kts[0].ID)
+	assert.Equal(t, "def", kts[1].ID)
+
+	m.Queue("srem", int64(1), nil)
+	m.Queue("del", int64(1), nil)
+	err = repo.Remove(*kt)
+	assert.NoError(t, err)
+	*/
+}
+
+func TestCreateRedisKey(t *testing.T) {
+	m := &testing2.RedisClientMock{}
+	r := redisRepo{
+		client:    m,
+		context:   context.Background(),
+		KeyPrefix: "webhook",
+	}
+
+	assert.Equal(t, "webhook-foobar", r.createRedisKey("foobar"))
+}

--- a/internal/webhook/redis_test.go
+++ b/internal/webhook/redis_test.go
@@ -21,7 +21,6 @@ package webhook
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	testing2 "github.com/bitmaelum/bitmaelum-suite/internal/testing"
@@ -48,17 +47,16 @@ func TestRedis(t *testing.T) {
 	cfg := ConfigHTTP{
 		URL: "https://foo.bar/test",
 	}
-	data, _ := json.Marshal(cfg)
 
 	h1 := hash.Hash("set 1")
-	w, _ := NewWebhook(h1, EventLocalDelivery, TypeHTTP, data)
+	w, _ := NewWebhook(h1, EventLocalDelivery, TypeHTTP, cfg)
 
 	m.Queue("set", "ok", nil)
 	m.Queue("sadd", int64(1), nil)
 	err = repo.Store(*w)
 	assert.NoError(t, err)
 
-	m.Queue("get", "{\"ID\":\"1721c5e1-892a-4a0c-b5bf-cedcab46f3cd\",\"Account\":\"set 1\",\"Type\":0,\"Event\":1,\"Enabled\":false,\"Config\":\"eyJVcmwiOiJodHRwczovL2Zvby5iYXIvdGVzdCJ9\"}", nil)
+	m.Queue("get", "{\"ID\":\"1721c5e1-892a-4a0c-b5bf-cedcab46f3cd\",\"Account\":\"set 1\",\"Type\":0,\"Event\":1,\"Enabled\":false,\"Config\":\"foobar\"}", nil)
 	kt2, err := repo.Fetch("abc")
 	assert.NoError(t, err)
 	assert.Equal(t, "1721c5e1-892a-4a0c-b5bf-cedcab46f3cd", kt2.ID)

--- a/internal/webhook/repository.go
+++ b/internal/webhook/repository.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package webhook
+
+import (
+	"path/filepath"
+
+	"github.com/bitmaelum/bitmaelum-suite/internal"
+	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
+	"github.com/go-redis/redis/v8"
+	"github.com/sirupsen/logrus"
+	bolt "go.etcd.io/bbolt"
+)
+
+
+type Storage interface {
+	FetchByHash(h hash.Hash) ([]Type, error)
+	Fetch(ID string) (*Type, error)
+	Store(w Type) error
+	Remove(w Type) error
+}
+
+// WebhookRepository is a repository to fetch and store webhooks
+type WebhookRepository struct {
+	storageRepo Storage
+}
+
+// NewRedisRepository initializes a new Redis repository
+func NewRedisRepository(opts *redis.Options) *WebhookRepository {
+	c := redis.NewClient(opts)
+
+	// Setup generic repository
+	repo := &redisRepo{
+		client:    &internal.RedisBridge{Client: *c},
+		context:   c.Context(),
+		KeyPrefix: "webhook",
+	}
+
+	return &WebhookRepository{
+		storageRepo: repo,
+	}
+}
+
+// NewBoltRepository initializes a new BoltDb repository
+func NewBoltRepository(dbPath string) *WebhookRepository {
+	p := filepath.Join(dbPath, BoltDBFile)
+	db, err := bolt.Open(p, 0600, nil)
+	if err != nil {
+		logrus.Error("Unable to open filepath ", p, err)
+		return nil
+	}
+
+	repo := boltRepo{
+		client:     db,
+		BucketName: "auth",
+	}
+
+	return &WebhookRepository{
+		storageRepo: repo,
+	}
+}
+
+// NewMockRepository initializes a new mock repository
+func NewMockRepository() *WebhookRepository {
+	repo := &mockRepo{
+		Webhooks: make(map[string]Type),
+	}
+
+	return &WebhookRepository{
+		storageRepo: repo,
+	}
+}
+
+// FetchByHash will fetch all api keys for the given address hash
+func (r WebhookRepository) FetchByHash(h hash.Hash) ([]Type, error) {
+	return r.storageRepo.FetchByHash(h)
+}
+
+// Fetch will get a single API key
+func (r WebhookRepository) Fetch(ID string) (*Type, error) {
+	return r.storageRepo.Fetch(ID)
+}
+
+// Store will store a single webhook
+func (r WebhookRepository) Store(w Type) error {
+	return r.storageRepo.Store(w)
+}
+
+// Remove will remove a single webhook
+func (r WebhookRepository) Remove(w Type) error {
+	return r.storageRepo.Remove(w)
+}

--- a/internal/webhook/repository.go
+++ b/internal/webhook/repository.go
@@ -29,7 +29,7 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
-
+// Storage is the main interface for fetching and storing webhook data
 type Storage interface {
 	FetchByHash(h hash.Hash) ([]Type, error)
 	Fetch(ID string) (*Type, error)
@@ -37,13 +37,13 @@ type Storage interface {
 	Remove(w Type) error
 }
 
-// WebhookRepository is a repository to fetch and store webhooks
-type WebhookRepository struct {
+// Repository is a repository to fetch and store webhooks
+type Repository struct {
 	storageRepo Storage
 }
 
 // NewRedisRepository initializes a new Redis repository
-func NewRedisRepository(opts *redis.Options) *WebhookRepository {
+func NewRedisRepository(opts *redis.Options) *Repository {
 	c := redis.NewClient(opts)
 
 	// Setup generic repository
@@ -53,13 +53,13 @@ func NewRedisRepository(opts *redis.Options) *WebhookRepository {
 		KeyPrefix: "webhook",
 	}
 
-	return &WebhookRepository{
+	return &Repository{
 		storageRepo: repo,
 	}
 }
 
 // NewBoltRepository initializes a new BoltDb repository
-func NewBoltRepository(dbPath string) *WebhookRepository {
+func NewBoltRepository(dbPath string) *Repository {
 	p := filepath.Join(dbPath, BoltDBFile)
 	db, err := bolt.Open(p, 0600, nil)
 	if err != nil {
@@ -72,38 +72,38 @@ func NewBoltRepository(dbPath string) *WebhookRepository {
 		BucketName: "auth",
 	}
 
-	return &WebhookRepository{
+	return &Repository{
 		storageRepo: repo,
 	}
 }
 
 // NewMockRepository initializes a new mock repository
-func NewMockRepository() *WebhookRepository {
+func NewMockRepository() *Repository {
 	repo := &mockRepo{
 		Webhooks: make(map[string]Type),
 	}
 
-	return &WebhookRepository{
+	return &Repository{
 		storageRepo: repo,
 	}
 }
 
 // FetchByHash will fetch all api keys for the given address hash
-func (r WebhookRepository) FetchByHash(h hash.Hash) ([]Type, error) {
+func (r Repository) FetchByHash(h hash.Hash) ([]Type, error) {
 	return r.storageRepo.FetchByHash(h)
 }
 
 // Fetch will get a single API key
-func (r WebhookRepository) Fetch(ID string) (*Type, error) {
+func (r Repository) Fetch(ID string) (*Type, error) {
 	return r.storageRepo.Fetch(ID)
 }
 
 // Store will store a single webhook
-func (r WebhookRepository) Store(w Type) error {
+func (r Repository) Store(w Type) error {
 	return r.storageRepo.Store(w)
 }
 
 // Remove will remove a single webhook
-func (r WebhookRepository) Remove(w Type) error {
+func (r Repository) Remove(w Type) error {
 	return r.storageRepo.Remove(w)
 }

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -36,16 +36,15 @@ type TypeEnum int
 
 // String convert type to string
 func (e TypeEnum) String() string {
-	return [...]string{"HTTP"}[e]
+	return [...]string{"HTTP", "Slack"}[e]
 }
 
 // Webhook destination types.
 const (
-	// TypeHTTP
-	TypeHTTP TypeEnum = iota // Simple HTTP endpoint
+	TypeHTTP  TypeEnum = iota // Simple HTTP endpoint
+	TypeSlack                 // Slack support
 	// TypeAmqp                            // Advanced Message Queue protocol
 	// TypeSQS                             // Amazon SQS support
-	// TypeSlack                           // Slack support
 )
 
 // Type is the webhook structure
@@ -74,6 +73,11 @@ type ConfigSQS struct {
 // ConfigSlack Configuration for TypeSlack (not yet implemented)
 type ConfigSlack struct {
 	WebhookURL string
+	Channel    string
+	Username   string
+	IconEmoji  string
+	IconUrl    string
+	Template   string
 }
 
 // NewWebhook creates a new webhook

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package webhook
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
+	"github.com/google/uuid"
+)
+
+var (
+	errWebhookNotFound = errors.New("webhook not found")
+)
+
+type TypeEnum int
+type EventEnum int
+
+const (
+	TypeHTTP TypeEnum = iota // Simple HTTP endpoint
+	// TypeAmqp                            // Advanced Message Queue protocol
+	// TypeSQS                             // Amazon SQS support
+	// TypeSlack                           // Slack support
+
+	EventNewMessage EventEnum = iota
+)
+
+type Type struct {
+	ID      string    // Id of the webhook
+	Account hash.Hash // account to which this webhook belongs to
+	Type    TypeEnum  // type of webhook
+	Event   EventEnum // event when this webhook is triggered
+	Enabled bool      // true when the webook is enabled
+	Config  []byte    // config for the given target.
+}
+
+type ConfigHTTP struct {
+	Url string
+}
+
+type ConfigSQS struct {
+	Arn             string
+	Region          string
+	AccesKeyId      string
+	SecretAccessKey string
+}
+
+type ConfigSlack struct {
+	WebhookUrl string
+}
+
+// @TODO: should we just have a queue system that will run at max 10 go routines for instance? Otherwise all go threads
+// might be depleted.
+
+// Execute will run the current webhook inside a separate go routine
+func (w *Type) Execute(payload string) {
+	go func() {
+		err := w.executeWebhook(payload)
+
+		if err != nil {
+			// @TODO: what to do when the webhook fails?
+		}
+	}()
+}
+
+func (w *Type) executeWebhook(payload string) error {
+	switch w.Type {
+	case TypeHTTP:
+		return w.execHttp(payload)
+	}
+
+	return errors.New("webhook: type not supported")
+}
+
+func (w *Type) execHttp(payload string) error {
+	cfg := &ConfigHTTP{}
+	err := json.Unmarshal(w.Config, cfg)
+	if err != nil {
+		return err
+	}
+
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+	resp, err := client.Post(cfg.Url, "application/json", bytes.NewReader([]byte(payload)))
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode >= 400 {
+		return errors.New("webhook: invalid status code returned from HTTP endpoint")
+	}
+
+	return nil
+}
+
+func NewWebhook(account hash.Hash, t TypeEnum, e EventEnum, cfg []byte) (*Type, error) {
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Type{
+		ID:      id.String(),
+		Account: account,
+		Type:    t,
+		Event:   e,
+		Enabled: false,
+		Config:  cfg,
+	}, nil
+}

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -43,8 +43,8 @@ func (e TypeEnum) String() string {
 const (
 	TypeHTTP  TypeEnum = iota // Simple HTTP endpoint
 	TypeSlack                 // Slack support
-	// TypeAmqp                            // Advanced Message Queue protocol
-	// TypeSQS                             // Amazon SQS support
+	// TypeAmqp               // Advanced Message Queue protocol
+	// TypeSQS                // Amazon SQS support
 )
 
 // Type is the webhook structure
@@ -76,7 +76,7 @@ type ConfigSlack struct {
 	Channel    string
 	Username   string
 	IconEmoji  string
-	IconUrl    string
+	IconURL    string
 	Template   string
 }
 

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -34,7 +34,7 @@ func TestWebhook(t *testing.T) {
 	}
 	data, _ := json.Marshal(cfg)
 
-	a, err := NewWebhook(hash.New("example!"), EventNewMessage, TypeHTTP, data)
+	a, err := NewWebhook(hash.New("example!"), EventLocalDelivery, TypeHTTP, data)
 	assert.NoError(t, err)
 
 	u, err := uuid.Parse(a.ID)
@@ -44,5 +44,5 @@ func TestWebhook(t *testing.T) {
 	assert.Equal(t, TypeHTTP, a.Type)
 	assert.Equal(t, "{\"URL\":\"https://foo.bar/test\"}", string(a.Config))
 	assert.False(t, a.Enabled)
-	assert.Equal(t, EventNewMessage, a.Event)
+	assert.Equal(t, EventLocalDelivery, a.Event)
 }

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package webhook
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/bitmaelum/bitmaelum-suite/pkg/hash"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWebhook(t *testing.T) {
+	cfg := ConfigHTTP{
+		Url: "https://foo.bar/test",
+	}
+	data, _ := json.Marshal(cfg)
+
+	a, err := NewWebhook(hash.New("example!"), TypeHTTP, EventNewMessage, data)
+	assert.NoError(t, err)
+
+
+	u, err := uuid.Parse(a.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, "VERSION_4", u.Version().String())
+	assert.Equal(t, "2e4551de804e27aacf20f9df5be3e8cd384ed64488b21ab079fb58e8c90068ab", a.Account.String())
+	assert.Equal(t, TypeHTTP, a.Type)
+	assert.Equal(t, "{\"Url\":\"https://foo.bar/test\"}", string(a.Config))
+	assert.False(t, a.Enabled)
+	assert.Equal(t, EventNewMessage, a.Event)
+}

--- a/tools/vault-edit/main.go
+++ b/tools/vault-edit/main.go
@@ -20,11 +20,7 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"os"
-	"os/exec"
 
 	"github.com/bitmaelum/bitmaelum-suite/internal"
 	"github.com/bitmaelum/bitmaelum-suite/internal/config"
@@ -48,38 +44,7 @@ func main() {
 		panic(err)
 	}
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "vd-")
-	if err != nil {
-		panic(err)
-	}
-	defer func() {
-		_ = os.Remove(tmpFile.Name())
-	}()
-
-	_, err = tmpFile.Write(v.RawData)
-	_ = tmpFile.Sync()
-	if err != nil {
-		panic(err)
-	}
-
-	editor := "/usr/bin/nano"
-	if os.Getenv("EDITOR") != "" {
-		editor = os.Getenv("EDITOR")
-	}
-
-	c := exec.Command(editor, tmpFile.Name())
-	c.Stdin = os.Stdin
-	c.Stdout = os.Stdout
-	err = c.Run()
-	if err != nil {
-		panic(err)
-	}
-	data, err := ioutil.ReadFile(tmpFile.Name())
-	if err != nil {
-		panic(err)
-	}
-
-	err = json.Unmarshal(data, &v.Store)
+	err = internal.OpenJSONFileEditor(v.RawData, v.Store)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The webhook system allows you to easily implement webhooks based on certain events on the SERVER side of things. This means that even though we can give some info (which account-hash, what message id etc), we cannot actually deliver information about a message itself.

So for instance, it will not (and never) be possible to trigger a webhook with the message's subject for instance.

However, the webhook can be an easy trigger for retrieving the message and process it in any way.


It works by having an internal dispatcher system running on X workers. Whenever an action can trigger a webhook, it will dispatch the event type and the account hash to the dispatcher system, which will in turn trigger all active webhooks for that account.

Webhooks are configurable via the API, just like API and auth keys.

Note that webhooks are by default disabled.

There is room for using external systems like SQS or ActiveMQ as message dispatcher.
It's also possible to have different kind of target destinations besides HTTP triggers. For instance, push to SQS, AMQP or even slack.

Todo:
- [X] webhook management through API
- [X] webhook dispatch system
- [x] webhook implementation on the different events