### PR TITLE
wip: Added initial version migration system

### DIFF
--- a/cmd/bm-client/cmd/account_list.go
+++ b/cmd/bm-client/cmd/account_list.go
@@ -100,13 +100,14 @@ func displayAccount(v *vault.Vault, info vault.AccountInfo) {
 		})
 	}
 
+	pk := info.GetActiveKey().PubKey
 	table.AppendBulk([][]string{
 		{"", ""},
 		{"Full name", info.Name},
 		{"Routing ID", info.RoutingID},
 		{"Routing Host", getHostByRoutingID(info.RoutingID, "unknown host")},
 		{"", ""},
-		{"Public key", strings.Join(chunks(info.PubKey.String(), 78), "\n")},
+		{"Public key", strings.Join(chunks(pk.String(), 78), "\n")},
 		{"Proof of work", fmt.Sprintf("%d bits", info.Pow.Bits)},
 	})
 

--- a/cmd/bm-client/cmd/message_compose.go
+++ b/cmd/bm-client/cmd/message_compose.go
@@ -116,7 +116,7 @@ var composeCmd = &cobra.Command{
 
 		// Setup addressing and compose the message
 		addressing := message.NewAddressing(message.SignedByTypeOrigin)
-		addressing.AddSender(fromInfo.Address, nil, fromInfo.Name, &fromInfo.PrivKey, routingInfo.Routing)
+		addressing.AddSender(fromInfo.Address, nil, fromInfo.Name, fromInfo.GetActiveKey().PrivKey, routingInfo.Routing)
 		addressing.AddRecipient(toAddr, nil, &recipientInfo.PublicKey)
 
 		err = handlers.ComposeMessage(addressing, *subject, *blocks, *attachments)

--- a/cmd/bm-client/cmd/organisation_list.go
+++ b/cmd/bm-client/cmd/organisation_list.go
@@ -101,11 +101,12 @@ func displayOrganisation(info vault.OrganisationInfo) {
 		{"Organisation hash", info.ToOrg().Hash.String()},
 	})
 
+	pk := info.GetActiveKey().PubKey
 	table.AppendBulk([][]string{
 		{"", ""},
 		{"Full name", info.FullName},
 		{"", ""},
-		{"Public key", strings.Join(chunks(info.PubKey.String(), 78), "\n")},
+		{"Public key", strings.Join(chunks(pk.String(), 78), "\n")},
 		{"Proof of work", fmt.Sprintf("%d bits", info.Pow.Bits)},
 	})
 

--- a/cmd/bm-client/cmd/webhook_create_slack.go
+++ b/cmd/bm-client/cmd/webhook_create_slack.go
@@ -77,7 +77,7 @@ var webhookCreateSlackCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
+		client, err := api.NewAuthenticated(*info.Address, info.GetActiveKey().PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
 		if err != nil {
 			logrus.Fatal(err)
 			os.Exit(1)

--- a/cmd/bm-client/handlers/auth_create.go
+++ b/cmd/bm-client/handlers/auth_create.go
@@ -43,7 +43,7 @@ func CreateAuthorizedKey(info *vault.AccountInfo, targetKey *bmcrypto.PubKey, va
 
 	// Create and sign key
 	k := key.NewAuthKey(info.Address.Hash(), targetKey, "", expiry, desc)
-	err := k.Sign(info.PrivKey)
+	err := k.Sign(info.GetActiveKey().PrivKey)
 	if err != nil {
 		return "", err
 	}
@@ -64,5 +64,5 @@ func getAPIClient(info *vault.AccountInfo) (*api.API, error) {
 		return nil, errNoRoutingID
 	}
 
-	return api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
+	return api.NewAuthenticated(*info.Address, info.GetActiveKey().PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
 }

--- a/cmd/bm-client/handlers/compose.go
+++ b/cmd/bm-client/handlers/compose.go
@@ -34,7 +34,7 @@ func ComposeMessage(addressing message.Addressing, subject string, b, a []string
 	}
 
 	// Setup API connection to the server
-	client, err := api.NewAuthenticated(*addressing.Sender.Address, addressing.Sender.PrivKey, addressing.Sender.Host, internal.JwtErrorFunc)
+	client, err := api.NewAuthenticated(*addressing.Sender.Address, *addressing.Sender.PrivKey, addressing.Sender.Host, internal.JwtErrorFunc)
 	if err != nil {
 		return err
 	}

--- a/cmd/bm-client/handlers/create_account.go
+++ b/cmd/bm-client/handlers/create_account.go
@@ -140,8 +140,8 @@ func CreateAccount(v *vault.Vault, bmAddr, name, token string, kt bmcrypto.KeyTy
 
 		fmt.Printf("* Adding your new account into the vault: ")
 		info = &vault.AccountInfo{
-			Address:   addr,
-			Name:      name,
+			Address: addr,
+			Name:    name,
 			Keys: []vault.KeyPair{
 				{
 					Generator:   e,

--- a/cmd/bm-client/handlers/create_organisation.go
+++ b/cmd/bm-client/handlers/create_organisation.go
@@ -73,9 +73,10 @@ func CreateOrganisation(v *vault.Vault, orgAddr, fullName string, orgValidations
 			privKey *bmcrypto.PrivKey
 			pubKey  *bmcrypto.PubKey
 			err     error
+			e       string
 		)
 
-		mnemonic, privKey, pubKey, err = internal.GenerateKeypairWithMnemonic(kt)
+		mnemonic, e, privKey, pubKey, err = internal.GenerateKeypairWithMnemonic(kt)
 
 		if err != nil {
 			fmt.Print(err)
@@ -95,8 +96,15 @@ func CreateOrganisation(v *vault.Vault, orgAddr, fullName string, orgValidations
 		info = &vault.OrganisationInfo{
 			Addr:        orgAddr,
 			FullName:    fullName,
-			PrivKey:     *privKey,
-			PubKey:      *pubKey,
+			Keys: []vault.KeyPair{
+				{
+					Generator:   e,
+					FingerPrint: pubKey.Fingerprint(),
+					PrivKey:     *privKey,
+					PubKey:      *pubKey,
+					Active:      true,
+				},
+			},
 			Pow:         proof,
 			Validations: val,
 		}

--- a/cmd/bm-client/handlers/create_organisation.go
+++ b/cmd/bm-client/handlers/create_organisation.go
@@ -94,8 +94,8 @@ func CreateOrganisation(v *vault.Vault, orgAddr, fullName string, orgValidations
 
 		fmt.Printf("* Adding your new organisation into the vault: ")
 		info = &vault.OrganisationInfo{
-			Addr:        orgAddr,
-			FullName:    fullName,
+			Addr:     orgAddr,
+			FullName: fullName,
 			Keys: []vault.KeyPair{
 				{
 					Generator:   e,

--- a/cmd/bm-client/handlers/create_organisation_invite.go
+++ b/cmd/bm-client/handlers/create_organisation_invite.go
@@ -70,7 +70,7 @@ func CreateOrganisationInvite(vault *vault.Vault, orgAddr, inviteAddr, shortRout
 	}
 
 	validUntil := pkginternal.TimeNow().Add(7 * 24 * time.Hour)
-	token, err := signature.NewInviteToken(hashAddr.Hash(), routingID, validUntil, oi.PrivKey)
+	token, err := signature.NewInviteToken(hashAddr.Hash(), routingID, validUntil, oi.GetActiveKey().PrivKey)
 	if err != nil {
 		fmt.Println("Error while generating token: ", err)
 		os.Exit(1)

--- a/cmd/bm-client/handlers/list_accounts.go
+++ b/cmd/bm-client/handlers/list_accounts.go
@@ -60,7 +60,7 @@ func ListAccounts(v *vault.Vault, displayKeys bool) {
 			route,
 		}
 		if displayKeys {
-			values = append(values, acc.PrivKey.S, acc.PubKey.S)
+			values = append(values, acc.GetActiveKey().PrivKey.S, acc.GetActiveKey().PubKey.S)
 		}
 
 		table.Append(values)

--- a/cmd/bm-client/handlers/list_messages.go
+++ b/cmd/bm-client/handlers/list_messages.go
@@ -56,7 +56,7 @@ func ListMessages(accounts []vault.AccountInfo, since time.Time) int {
 			continue
 		}
 
-		client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
+		client, err := api.NewAuthenticated(*info.Address, info.GetActiveKey().PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
 		if err != nil {
 			continue
 		}
@@ -120,11 +120,11 @@ func displayBox(client *api.API, account *vault.AccountInfo, box string, table *
 	}
 
 	// Sort messages first
-	msort := mailbox.NewMessageSort(&account.PrivKey, mb.Messages, mailbox.SortDate, true)
+	msort := mailbox.NewMessageSort(account.GetActiveKey().PrivKey, mb.Messages, mailbox.SortDate, true)
 	sort.Sort(&msort)
 
 	for _, msg := range mb.Messages {
-		key, err := bmcrypto.Decrypt(account.PrivKey, msg.Header.Catalog.TransactionID, msg.Header.Catalog.EncryptedKey)
+		key, err := bmcrypto.Decrypt(account.GetActiveKey().PrivKey, msg.Header.Catalog.TransactionID, msg.Header.Catalog.EncryptedKey)
 		if err != nil {
 			continue
 		}

--- a/cmd/bm-client/handlers/list_organisations.go
+++ b/cmd/bm-client/handlers/list_organisations.go
@@ -52,7 +52,7 @@ func ListOrganisations(v *vault.Vault, displayKeys bool) {
 				org.ToOrg().Hash.String(),
 			}
 			if displayKeys {
-				values = append(values, org.PrivKey.S, org.PubKey.S)
+				values = append(values, org.GetActiveKey().PrivKey.S, org.GetActiveKey().PubKey.S)
 			}
 
 			table.Append(values)
@@ -86,7 +86,7 @@ func ListOrganisations(v *vault.Vault, displayKeys bool) {
 			}
 
 			if displayKeys {
-				values = append(values, org.PrivKey.S, org.PubKey.S)
+				values = append(values, org.GetActiveKey().PrivKey.S, org.GetActiveKey().PubKey.S)
 			}
 
 			table.Append(values)

--- a/cmd/bm-client/handlers/otp.go
+++ b/cmd/bm-client/handlers/otp.go
@@ -60,7 +60,7 @@ func OtpGenerate(info *vault.AccountInfo, otpServer *string) {
 		oi, err := resolver.ResolveOrganisation(*orgHash)
 		if err == nil {
 			// Generate secret on the client and compute OTP
-			secret, err := bmcrypto.KeyExchange(info.PrivKey, oi.PublicKey)
+			secret, err := bmcrypto.KeyExchange(info.GetActiveKey().PrivKey, oi.PublicKey)
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/cmd/bm-client/handlers/read_message.go
+++ b/cmd/bm-client/handlers/read_message.go
@@ -41,7 +41,7 @@ import (
 
 // ReadMessages will read a specific message blocks
 func ReadMessages(info *vault.AccountInfo, routingInfo *resolver.RoutingInfo, box, messageID string, since time.Time) {
-	client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
+	client, err := api.NewAuthenticated(*info.Address, info.GetActiveKey().PrivKey, routingInfo.Routing, internal.JwtErrorFunc)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func ReadMessages(info *vault.AccountInfo, routingInfo *resolver.RoutingInfo, bo
 
 	// iterate list until we quit
 	for !readDone {
-		decryptedMsg, err := messageList[idx].Decrypt(info.PrivKey)
+		decryptedMsg, err := messageList[idx].Decrypt(info.GetActiveKey().PrivKey)
 		if err != nil {
 			fmt.Println("Cannot decrypt message: ", err)
 		} else {

--- a/cmd/bm-client/internal/cli.go
+++ b/cmd/bm-client/internal/cli.go
@@ -44,7 +44,7 @@ func GetClientAndInfo(acc string) (*vault.Vault, *vault.AccountInfo, *api.API, e
 		return nil, nil, nil, errors.New("cannot find routing ID for this account")
 	}
 
-	client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing, JwtErrorFunc)
+	client, err := api.NewAuthenticated(*info.Address, info.GetActiveKey().PrivKey, routingInfo.Routing, JwtErrorFunc)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/cmd/bm-client/internal/mailbox/sort.go
+++ b/cmd/bm-client/internal/mailbox/sort.go
@@ -47,10 +47,10 @@ const (
 )
 
 // NewMessageSort will create a new sorted based on the given sortfield and ascending/descending order
-func NewMessageSort(key *bmcrypto.PrivKey, messages []api.MailboxMessagesMessage, field SortField, asc bool) MessageSort {
+func NewMessageSort(key bmcrypto.PrivKey, messages []api.MailboxMessagesMessage, field SortField, asc bool) MessageSort {
 	ms := MessageSort{
 		Messages:       messages,
-		key:            key,
+		key:            &key,
 		openedCatalogs: make(map[string]*message.Catalog),
 		asc:            asc,
 	}

--- a/cmd/bm-json/cmd/account.go
+++ b/cmd/bm-json/cmd/account.go
@@ -43,9 +43,11 @@ var accountCmd = &cobra.Command{
 
 			privkey := ""
 			if *accDisplayPrivKey {
-				privkey = acc.PrivKey.String()
+				pk := acc.GetActiveKey().PrivKey
+				privkey = pk.String()
 			}
 
+			pk := acc.GetActiveKey().PubKey
 			out = append(out, output.JSONT{
 				"address": output.JSONT{
 					"hash":       acc.Address.Hash().String(),
@@ -56,7 +58,7 @@ var accountCmd = &cobra.Command{
 				"name":          acc.Name,
 				"routing_id":    acc.RoutingID,
 				"private_key":   privkey,
-				"public_key":    acc.PubKey.String(),
+				"public_key":    pk.String(),
 				"proof_of_work": acc.Pow.String(),
 				"settings":      acc.Settings,
 			})

--- a/cmd/bm-json/cmd/message.go
+++ b/cmd/bm-json/cmd/message.go
@@ -56,7 +56,7 @@ var messageCmd = &cobra.Command{
 			GenerateAttachmentReader: client.GenerateAPIAttachmentReader(info.Address.Hash()),
 		}
 
-		dMsg, err := em.Decrypt(info.PrivKey)
+		dMsg, err := em.Decrypt(info.GetActiveKey().PrivKey)
 		if err != nil {
 			output.JSONErrorStrOut("cannot decrypt message")
 			os.Exit(1)

--- a/cmd/bm-json/cmd/organisation.go
+++ b/cmd/bm-json/cmd/organisation.go
@@ -43,14 +43,16 @@ var organisationCmd = &cobra.Command{
 
 			privkey := ""
 			if *orgDisplayPrivKey {
-				privkey = org.PrivKey.String()
+				pk := org.GetActiveKey().PrivKey
+				privkey = pk.String()
 			}
 
+			pk := org.GetActiveKey().PubKey
 			out = append(out, output.JSONT{
 				"address":       org.Addr,
 				"full_name":     org.FullName,
 				"private_key":   privkey,
-				"public_key":    org.PubKey.String(),
+				"public_key":    pk.String(),
 				"proof_of_work": org.Pow.String(),
 				"validations":   org.Validations,
 			})

--- a/cmd/bm-json/internal/cli.go
+++ b/cmd/bm-json/internal/cli.go
@@ -44,7 +44,7 @@ func GetClientAndInfo(acc string) (*vault.Vault, *vault.AccountInfo, *api.API, e
 		return nil, nil, nil, errors.New("cannot find routing ID for this account")
 	}
 
-	client, err := api.NewAuthenticated(*info.Address, &info.PrivKey, routingInfo.Routing, JwtJSONErrorFunc)
+	client, err := api.NewAuthenticated(*info.Address, info.GetActiveKey().PrivKey, routingInfo.Routing, JwtJSONErrorFunc)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/cmd/bm-send/main.go
+++ b/cmd/bm-send/main.go
@@ -111,7 +111,7 @@ func main() {
 
 	// Setup addressing
 	addressing := message.NewAddressing(message.SignedByTypeAuthorized)
-	addressing.AddSender(fromAddr, nil, opts.FromName, privKey, senderInfo.RoutingInfo.Routing)
+	addressing.AddSender(fromAddr, nil, opts.FromName, *privKey, senderInfo.RoutingInfo.Routing)
 	addressing.AddRecipient(toAddr, nil, &recipientInfo.PublicKey)
 
 	// Compose mail
@@ -122,7 +122,7 @@ func main() {
 	}
 
 	// Send mail
-	client, err := api.NewAuthenticated(*fromAddr, privKey, senderInfo.RoutingInfo.Routing, apiErrorFunc)
+	client, err := api.NewAuthenticated(*fromAddr, *privKey, senderInfo.RoutingInfo.Routing, apiErrorFunc)
 	if err != nil {
 		fmt.Println("cannot connect to api")
 		os.Exit(1)

--- a/cmd/bm-server/processor/retry_queue.go
+++ b/cmd/bm-server/processor/retry_queue.go
@@ -154,7 +154,7 @@ func sendPostmasterMail(toHash hash.Hash, subject string, body string) error {
 	senderName := fmt.Sprintf("postmaster at %s", config.Server.Server.Hostname)
 
 	addressing := message.NewAddressing(message.SignedByTypeServer)
-	addressing.AddSender(nil, fromHash, senderName, &config.Routing.PrivateKey, "host")
+	addressing.AddSender(nil, fromHash, senderName, config.Routing.PrivateKey, "host")
 	addressing.AddRecipient(nil, &toHash, &addr.PublicKey)
 
 	// Create a single block with our body

--- a/internal/api/account.go
+++ b/internal/api/account.go
@@ -61,7 +61,7 @@ func (api *API) CreateAccount(info vault.AccountInfo, token string) error {
 		UserHash:    info.Address.LocalHash(),
 		OrgHash:     info.Address.OrgHash(),
 		Token:       token,
-		PublicKey:   info.PubKey,
+		PublicKey:   info.GetActiveKey().PubKey,
 		ProofOfWork: *info.Pow,
 	}
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -79,9 +79,9 @@ func NewAnonymous(host string, f serverErrorFunc) (*API, error) {
 }
 
 // NewAuthenticated creates a new client that connects to a BitMaelum Server with specific credentials (normally client-to-server communications)
-func NewAuthenticated(addr address.Address, key *bmcrypto.PrivKey, host string, f serverErrorFunc) (*API, error) {
+func NewAuthenticated(addr address.Address, key bmcrypto.PrivKey, host string, f serverErrorFunc) (*API, error) {
 	// Create token based on the private key of the user
-	jwtToken, err := GenerateJWTToken(addr.Hash(), *key)
+	jwtToken, err := GenerateJWTToken(addr.Hash(), key)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func NewAuthenticated(addr address.Address, key *bmcrypto.PrivKey, host string, 
 		Host:          host,
 		JWTToken:      jwtToken,
 		Address:       addr,
-		Key:           key,
+		Key:           &key,
 		AllowInsecure: config.Client.Server.AllowInsecure || config.Server.Server.AllowInsecure,
 		Debug:         config.Client.Server.DebugHTTP,
 		ErrorFunc:     f,

--- a/internal/config/routing.go
+++ b/internal/config/routing.go
@@ -100,7 +100,7 @@ func GenerateRouting() (string, *RoutingConfig, error) {
 		return "", nil, err
 	}
 
-	mnemonic, privKey, pubKey, err := internal.GenerateKeypairWithMnemonic(kt)
+	mnemonic, _, privKey, pubKey, err := internal.GenerateKeypairWithMnemonic(kt)
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/message/catalog_test.go
+++ b/internal/message/catalog_test.go
@@ -50,7 +50,7 @@ func TestCatalogNewCatalog(t *testing.T) {
 
 	privkey, pubkey, _ := testing2.ReadTestKey("../../testdata/key-ed25519-1.json")
 	addressing := NewAddressing(SignedByTypeOrigin)
-	addressing.AddSender(nil, &h, "john doe", privkey, "host.example")
+	addressing.AddSender(nil, &h, "john doe", *privkey, "host.example")
 	addressing.AddRecipient(addrTo, nil, pubkey)
 
 	c = NewCatalog(addressing, "subject")
@@ -217,7 +217,7 @@ func genCatalog() *Catalog {
 
 	privkey, pubkey, _ := testing2.ReadTestKey("../../testdata/key-ed25519-1.json")
 	addressing := NewAddressing(SignedByTypeOrigin)
-	addressing.AddSender(addrFrom, nil, "john doe", privkey, "host.example")
+	addressing.AddSender(addrFrom, nil, "john doe", *privkey, "host.example")
 	addressing.AddRecipient(addrTo, nil, pubkey)
 
 	return NewCatalog(addressing, "subject")

--- a/internal/message/compose_test.go
+++ b/internal/message/compose_test.go
@@ -36,7 +36,7 @@ func TestCompose(t *testing.T) {
 
 	// Setup addressing
 	addressing := NewAddressing(SignedByTypeOrigin)
-	addressing.AddSender(sender, nil, "", privKey, "12345678")
+	addressing.AddSender(sender, nil, "", *privKey, "12345678")
 	addressing.AddRecipient(recipient, nil, pubKey)
 
 	env, err := Compose(addressing, "foobar", []string{"default,foobar"}, nil)

--- a/internal/message/envelope.go
+++ b/internal/message/envelope.go
@@ -73,11 +73,11 @@ func NewAddressing(signType SignedByType) Addressing {
 }
 
 // AddSender will add sender information to the addressing
-func (a *Addressing) AddSender(addr *address.Address, h *hash.Hash, name string, key *bmcrypto.PrivKey, host string) {
+func (a *Addressing) AddSender(addr *address.Address, h *hash.Hash, name string, key bmcrypto.PrivKey, host string) {
 	a.Sender.Address = addr
 	a.Sender.Hash = h
 	a.Sender.Name = name
-	a.Sender.PrivKey = key
+	a.Sender.PrivKey = &key
 	a.Sender.Host = host
 }
 

--- a/internal/mnemonic.go
+++ b/internal/mnemonic.go
@@ -47,8 +47,6 @@ func GenerateKeypairWithMnemonic(kt bmcrypto.KeyType) (string, string, *bmcrypto
 		return "", "", nil, nil, err
 	}
 
-
-
 	return kt.String() + " " + mnemonic, hex.EncodeToString(e), privKey, pubKey, nil
 }
 

--- a/internal/mnemonic.go
+++ b/internal/mnemonic.go
@@ -21,6 +21,7 @@ package internal
 
 import (
 	"bytes"
+	"encoding/hex"
 	"strings"
 
 	"github.com/bitmaelum/bitmaelum-suite/pkg/bmcrypto"
@@ -28,25 +29,27 @@ import (
 )
 
 // GenerateKeypairWithMnemonic generates a mnemonic, and a RSA keypair that can be generated through the same mnemonic again.
-func GenerateKeypairWithMnemonic(kt bmcrypto.KeyType) (string, *bmcrypto.PrivKey, *bmcrypto.PubKey, error) {
+func GenerateKeypairWithMnemonic(kt bmcrypto.KeyType) (string, string, *bmcrypto.PrivKey, *bmcrypto.PubKey, error) {
 	// Generate large enough random string
 	e, err := bip39.NewEntropy(192)
 	if err != nil {
-		return "", nil, nil, err
+		return "", "", nil, nil, err
 	}
 
 	// Generate Mnemonic words
 	mnemonic, err := bip39.NewMnemonic(e)
 	if err != nil {
-		return "", nil, nil, err
+		return "", "", nil, nil, err
 	}
 
 	privKey, pubKey, err := kt.GenerateKeyPair(bytes.NewReader(e))
 	if err != nil {
-		return "", nil, nil, err
+		return "", "", nil, nil, err
 	}
 
-	return kt.String() + " " + mnemonic, privKey, pubKey, nil
+
+
+	return kt.String() + " " + mnemonic, hex.EncodeToString(e), privKey, pubKey, nil
 }
 
 // GenerateKeypairFromMnemonic generates a keypair based on the given mnemonic

--- a/internal/mnemonic_test.go
+++ b/internal/mnemonic_test.go
@@ -29,7 +29,7 @@ import (
 func TestGenerateED25519KeypairFromMnemonic(t *testing.T) {
 	kt, err := bmcrypto.FindKeyType("ed25519")
 	assert.NoError(t, err)
-	s, e, priv1, pub1, err := GenerateKeypairWithMnemonic(kt)
+	s, _, priv1, pub1, err := GenerateKeypairWithMnemonic(kt)
 	assert.NoError(t, err)
 
 	priv2, pub2, err := GenerateKeypairFromMnemonic(s)
@@ -42,7 +42,7 @@ func TestGenerateED25519KeypairFromMnemonic(t *testing.T) {
 func TestGenerateRSAKeypairFromMnemonic(t *testing.T) {
 	kt, err := bmcrypto.FindKeyType("rsa")
 	assert.NoError(t, err)
-	s, e, priv1, pub1, err := GenerateKeypairWithMnemonic(kt)
+	s, _, priv1, pub1, err := GenerateKeypairWithMnemonic(kt)
 	assert.NoError(t, err)
 
 	priv2, pub2, err := GenerateKeypairFromMnemonic(s)

--- a/internal/mnemonic_test.go
+++ b/internal/mnemonic_test.go
@@ -29,7 +29,7 @@ import (
 func TestGenerateED25519KeypairFromMnemonic(t *testing.T) {
 	kt, err := bmcrypto.FindKeyType("ed25519")
 	assert.NoError(t, err)
-	s, priv1, pub1, err := GenerateKeypairWithMnemonic(kt)
+	s, e, priv1, pub1, err := GenerateKeypairWithMnemonic(kt)
 	assert.NoError(t, err)
 
 	priv2, pub2, err := GenerateKeypairFromMnemonic(s)
@@ -42,7 +42,7 @@ func TestGenerateED25519KeypairFromMnemonic(t *testing.T) {
 func TestGenerateRSAKeypairFromMnemonic(t *testing.T) {
 	kt, err := bmcrypto.FindKeyType("rsa")
 	assert.NoError(t, err)
-	s, priv1, pub1, err := GenerateKeypairWithMnemonic(kt)
+	s, e, priv1, pub1, err := GenerateKeypairWithMnemonic(kt)
 	assert.NoError(t, err)
 
 	priv2, pub2, err := GenerateKeypairFromMnemonic(s)

--- a/internal/resolver/service.go
+++ b/internal/resolver/service.go
@@ -141,10 +141,10 @@ func (s *Service) ResolveOrganisation(orgHash hash.Hash) (*OrganisationInfo, err
 func (s *Service) UploadAddressInfo(info vault.AccountInfo, orgToken string) error {
 	return s.repo.UploadAddress(*info.Address, &AddressInfo{
 		Hash:      info.Address.Hash().String(),
-		PublicKey: info.PubKey,
+		PublicKey: info.GetActiveKey().PubKey,
 		RoutingID: info.RoutingID,
 		Pow:       info.Pow.String(),
-	}, info.PrivKey, *info.Pow, orgToken)
+	}, info.GetActiveKey().PrivKey, *info.Pow, orgToken)
 }
 
 // UploadRoutingInfo uploads resolve information to one (or more) resolvers
@@ -156,10 +156,10 @@ func (s *Service) UploadRoutingInfo(info RoutingInfo, privKey *bmcrypto.PrivKey)
 func (s *Service) UploadOrganisationInfo(info vault.OrganisationInfo) error {
 	return s.repo.UploadOrganisation(&OrganisationInfo{
 		Hash:        hash.New(info.Addr).String(),
-		PublicKey:   info.PubKey,
+		PublicKey:   info.GetActiveKey().PubKey,
 		Pow:         info.Pow.String(),
 		Validations: info.Validations,
-	}, info.PrivKey, *info.Pow)
+	}, info.GetActiveKey().PrivKey, *info.Pow)
 }
 
 // GetConfig returns the configuration from the given repo, or a default configuration on error

--- a/internal/vault/account.go
+++ b/internal/vault/account.go
@@ -30,6 +30,7 @@ import (
 
 var errAccountNotFound = errors.New("cannot find account")
 
+// KeyPair is a structure with key information
 type KeyPair struct {
 	Generator   string           `json:"generator"`   // The generator string that will generate the given keypair
 	FingerPrint string           `json:"fingerprint"` // The sha1 fingerprint for this key
@@ -64,6 +65,7 @@ type AccountInfo struct {
 	RoutingID string                   `json:"routing_id"`      // ID of the routing used
 }
 
+// GetActiveKey will return the currently active key from the list of keys in the info structure
 func (info AccountInfo) GetActiveKey() KeyPair {
 	for _, k := range info.Keys {
 		if k.Active {

--- a/internal/vault/account_test.go
+++ b/internal/vault/account_test.go
@@ -97,10 +97,17 @@ func TestVaultGetDefaultAccount(t *testing.T) {
 
 func TestInfoToOrg(t *testing.T) {
 	info := &OrganisationInfo{
-		Addr:        "foo",
-		FullName:    "bar",
-		PrivKey:     bmcrypto.PrivKey{},
-		PubKey:      bmcrypto.PubKey{},
+		Addr:     "foo",
+		FullName: "bar",
+		Keys: []KeyPair{
+			{
+				Generator:   "",
+				FingerPrint: "",
+				PrivKey:     bmcrypto.PrivKey{},
+				PubKey:      bmcrypto.PubKey{},
+				Active:      true,
+			},
+		},
 		Pow:         proofofwork.New(22, "foobar", 1234),
 		Validations: nil,
 	}

--- a/internal/vault/migrate.go
+++ b/internal/vault/migrate.go
@@ -1,0 +1,93 @@
+package vault
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+func MigrateVault(data []byte, fromVersion int) (*StoreType, error){
+	storeV0 := make([]AccountInfoV1, 0)
+	storeV1 := &StoreTypeV1{}
+	storeV2 := &StoreType{}
+
+	// Read the correct initial data format
+	switch fromVersion {
+	case VersionV0:
+		err := json.Unmarshal(data, &storeV0)
+		if err != nil {
+			return nil, err
+		}
+	case VersionV1:
+		err := json.Unmarshal(data, &storeV1)
+		if err != nil {
+			return nil, err
+		}
+	case VersionV2:
+		err := json.Unmarshal(data, &storeV1)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Iterate migrations until we reach the latest version
+	for fromVersion < LatestVaultVersion {
+		switch fromVersion {
+		case VersionV0:
+			/*
+			 * V0 -> V1 adds organisations
+			 */
+			storeV1.Accounts = storeV0
+			storeV1.Organisations = []OrganisationInfoV1{}
+
+			fromVersion++
+		case VersionV1:
+			/*
+			 * V1 -> V2 has multiple keys in both organisation and accounts
+			 */
+			for _, accV1 := range storeV1.Accounts {
+				accV2 := &AccountInfo{}
+				accV2.Address = accV1.Address
+				accV2.Pow = accV1.Pow
+				accV2.RoutingID = accV1.RoutingID
+				accV2.Name = accV1.Name
+				accV2.Settings = accV1.Settings
+				accV2.Keys = []KeyPair{
+					{
+						Generator:   "",
+						FingerPrint: accV1.PubKey.Fingerprint(),
+						PrivKey:     accV1.PrivKey,
+						PubKey:      accV1.PubKey,
+						Active:      true,
+					},
+				}
+				storeV2.Accounts = append(storeV2.Accounts, *accV2)
+			}
+
+			for _, orgV1 := range storeV1.Organisations {
+				orgV2 := &OrganisationInfo{}
+				orgV2.Addr = orgV1.Addr
+				orgV2.Pow = orgV1.Pow
+				orgV2.FullName = orgV1.FullName
+				orgV2.Validations = orgV1.Validations
+				orgV2.Keys = []KeyPair{
+					{
+						Generator:   "",
+						FingerPrint: orgV1.PubKey.Fingerprint(),
+						PrivKey:     orgV1.PrivKey,
+						PubKey:      orgV1.PubKey,
+						Active:      true,
+					},
+				}
+				storeV2.Organisations = append(storeV2.Organisations, *orgV2)
+			}
+
+			fromVersion++
+
+		case VersionV2:
+			// Latest version, no need to migrate
+			return storeV2, nil
+		}
+	}
+
+	return nil, errors.New("error while running migrations on the vault")
+}

--- a/internal/vault/migrate.go
+++ b/internal/vault/migrate.go
@@ -1,3 +1,22 @@
+// Copyright (c) 2021 BitMaelum Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 package vault
 
 import (
@@ -5,7 +24,8 @@ import (
 	"errors"
 )
 
-func MigrateVault(data []byte, fromVersion int) (*StoreType, error){
+// MigrateVault will migrate a vault from a specific version all the way to the latest version
+func MigrateVault(data []byte, fromVersion int) (*StoreType, error) {
 	storeV0 := make([]AccountInfoV1, 0)
 	storeV1 := &StoreTypeV1{}
 	storeV2 := &StoreType{}
@@ -23,14 +43,14 @@ func MigrateVault(data []byte, fromVersion int) (*StoreType, error){
 			return nil, err
 		}
 	case VersionV2:
-		err := json.Unmarshal(data, &storeV1)
+		err := json.Unmarshal(data, &storeV2)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	// Iterate migrations until we reach the latest version
-	for fromVersion < LatestVaultVersion {
+	for fromVersion <= LatestVaultVersion {
 		switch fromVersion {
 		case VersionV0:
 			/*

--- a/internal/vault/organisation.go
+++ b/internal/vault/organisation.go
@@ -59,6 +59,7 @@ func (info OrganisationInfo) ToOrg() *organisation.Organisation {
 	}
 }
 
+// GetActiveKey will return the currently active key from the list of keys in the info structure
 func (info OrganisationInfo) GetActiveKey() KeyPair {
 	for _, k := range info.Keys {
 		if k.Active {

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -43,7 +43,7 @@ const (
 	VersionV2        // Multi key
 )
 
-// Latest vault version. Everything below this version will be automatically migrated to this version
+// LatestVaultVersion Everything below this version will be automatically migrated to this version
 const LatestVaultVersion = VersionV2
 
 // Override for testing purposes

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -36,11 +36,15 @@ var (
 	errNoPathSet           = errors.New("vault path is not set")
 )
 
-// VersionV0 is the first version that uses versioning
+// Vault versions
 const (
-	VersionV0 = iota
-	VersionV1
+	VersionV0 = iota // Only accounts
+	VersionV1        // Accounts + organisations
+	VersionV2        // Multi key
 )
+
+// Latest vault version. Everything below this version will be automatically migrated to this version
+const LatestVaultVersion = VersionV2
 
 // Override for testing purposes
 var fs = afero.NewOsFs()
@@ -56,6 +60,12 @@ var (
 type StoreType struct {
 	Accounts      []AccountInfo      `json:"accounts"`
 	Organisations []OrganisationInfo `json:"organisations"`
+}
+
+// StoreTypeV1 hold the actual data that is encrypted inside the vault
+type StoreTypeV1 struct {
+	Accounts      []AccountInfoV1      `json:"accounts"`
+	Organisations []OrganisationInfoV1 `json:"organisations"`
 }
 
 // Vault defines our vault with path and password. Only the accounts should be exported
@@ -90,20 +100,24 @@ func NewPersistent(p, pass string) *Vault {
 // so we should not save any data once we detected this.
 func (v *Vault) sanityCheck() bool {
 	for _, acc := range v.Store.Accounts {
-		if acc.PrivKey.S == "" {
-			return false
-		}
-		if acc.PubKey.S == "" {
-			return false
+		for _, k := range acc.Keys {
+			if k.PrivKey.S == "" {
+				return false
+			}
+			if k.PubKey.S == "" {
+				return false
+			}
 		}
 	}
 
 	for _, org := range v.Store.Organisations {
-		if org.PrivKey.S == "" {
-			return false
-		}
-		if org.PubKey.S == "" {
-			return false
+		for _, k := range org.Keys {
+			if k.PrivKey.S == "" {
+				return false
+			}
+			if k.PubKey.S == "" {
+				return false
+			}
 		}
 	}
 

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -52,11 +52,18 @@ func TestNew(t *testing.T) {
 
 	addr, _ := address.NewAddress("foobar!")
 	acc := &AccountInfo{
-		Address:   addr,
-		Name:      "Foo Bar",
-		Settings:  nil,
-		PrivKey:   *privKey,
-		PubKey:    *pubKey,
+		Address:  addr,
+		Name:     "Foo Bar",
+		Settings: nil,
+		Keys: []KeyPair{
+			{
+				Generator:   "",
+				FingerPrint: pubKey.Fingerprint(),
+				PrivKey:     *privKey,
+				PubKey:      *pubKey,
+				Active:      true,
+			},
+		},
 		Pow:       &proofofwork.ProofOfWork{},
 		RoutingID: "12345678",
 	}

--- a/tools/jwt/main.go
+++ b/tools/jwt/main.go
@@ -60,20 +60,20 @@ func main() {
 	}
 
 	fmt.Println("PRIV:")
-	fmt.Printf("%s\n", info.PrivKey)
+	fmt.Printf("%s\n", info.GetActiveKey().PrivKey)
 
 	fmt.Println("PUB:")
-	fmt.Printf("%s\n", info.PubKey)
+	fmt.Printf("%s\n", info.GetActiveKey().PubKey)
 	fmt.Println("")
 
-	ts, err := api.GenerateJWTToken(fromAddr.Hash(), info.PrivKey)
+	ts, err := api.GenerateJWTToken(fromAddr.Hash(), info.GetActiveKey().PrivKey)
 	if err != nil {
 		logrus.Fatal(err)
 	}
 	fmt.Println(ts)
 	fmt.Println("")
 
-	token, err := api.ValidateJWTToken(ts, fromAddr.Hash(), info.PubKey)
+	token, err := api.ValidateJWTToken(ts, fromAddr.Hash(), info.GetActiveKey().PubKey)
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/tools/readmail/main.go
+++ b/tools/readmail/main.go
@@ -87,7 +87,7 @@ func main() {
 		panic(err)
 	}
 
-	decryptedKey, err := bmcrypto.Decrypt(info.PrivKey, header.Catalog.TransactionID, header.Catalog.EncryptedKey)
+	decryptedKey, err := bmcrypto.Decrypt(info.GetActiveKey().PrivKey, header.Catalog.TransactionID, header.Catalog.EncryptedKey)
 	if err != nil {
 		panic(err)
 	}

--- a/tools/resolve-auth/main.go
+++ b/tools/resolve-auth/main.go
@@ -51,7 +51,7 @@ func main() {
 	}
 
 	hashed := []byte(info.Address.Hash().String() + info.RoutingID)
-	sig, err := bmcrypto.Sign(info.PrivKey, hashed)
+	sig, err := bmcrypto.Sign(info.GetActiveKey().PrivKey, hashed)
 	if err != nil {
 		logrus.Fatal("Cannot sign")
 		os.Exit(1)


### PR DESCRIPTION
I think this is an ok way to make sure vaults are always upgraded to the latest version.

Pro's:
  - vault are automatically upgraded to the latest version if not done already
  - no manual intervention needed.
 
Cons:
  - we must make sure we are always able to migrate to the newer vault (what about new values?)
  - We must keep the old structures in the code (like AccountInfoV1 etc). We can move this aways into migration files or something.